### PR TITLE
🔧 fix(deps): update proconnect.core to use mostUsedFreeEmailDomains from data export

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -263,7 +263,7 @@
       "name": "@~/identite-proconnect.lib",
       "version": "1.0.0",
       "dependencies": {
-        "@gouvfr-lasuite/proconnect.core": "0.5.0",
+        "@gouvfr-lasuite/proconnect.core": "0.6.0",
         "@gouvfr-lasuite/proconnect.entreprise": "0.0.0",
         "@gouvfr-lasuite/proconnect.identite": "0.8.0",
         "@gouvfr-lasuite/proconnect.insee": "0.3.2",
@@ -386,7 +386,7 @@
       "name": "@~/organizations.api",
       "version": "1.0.0",
       "dependencies": {
-        "@gouvfr-lasuite/proconnect.core": "0.5.0",
+        "@gouvfr-lasuite/proconnect.core": "0.6.0",
         "@~/app.layout": "workspace:*",
         "@~/app.middleware": "workspace:*",
         "@~/app.ui": "workspace:*",
@@ -617,7 +617,7 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.5", "", { "os": "win32", "cpu": "x64" }, "sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g=="],
 
-    "@gouvfr-lasuite/proconnect.core": ["@gouvfr-lasuite/proconnect.core@0.5.0", "", { "dependencies": { "@types/bcryptjs": "^2.4.6", "@types/lodash-es": "^4.17.12", "@types/oidc-provider": "^8.5.2", "@zootools/email-spell-checker": "^1.12.0", "bcryptjs": "^2.4.3", "is-disposable-email-domain": "^1.0.7", "lodash-es": "^4.17.21", "nanoid": "^5.0.9", "tld-extract": "^2.1.0" } }, "sha512-dhVcvfkP8jf3sB/hf8V5W8I5aCH4u+wLX2QvSBOcmb9hq1Ejee3cxS21Qp0//+nUQsqTs5Wk0csw+eWDFdqCaw=="],
+    "@gouvfr-lasuite/proconnect.core": ["@gouvfr-lasuite/proconnect.core@0.6.0", "", { "dependencies": { "@types/lodash-es": "^4.17.12", "@types/oidc-provider": "^8.8.1", "@zootools/email-spell-checker": "^1.12.0", "bcryptjs": "^3.0.2", "is-disposable-email-domain": "^1.0.7", "lodash-es": "^4.17.21", "nanoid": "^5.1.5", "tld-extract": "^2.1.0" } }, "sha512-NBxC3ROA2vEJrtNdmjGVJHku9KJLOC6+ZmtrCcjKqRjuf7I294nLoK3rT9RTTqfiF7zLVqdiIOEOgPIZ+hoGAA=="],
 
     "@gouvfr-lasuite/proconnect.crisp": ["@gouvfr-lasuite/proconnect.crisp@0.5.0", "", {}, "sha512-WplyIj6BFcAp0CIGh2QvmF5EhullPzXZg01xDgEJBZ9d1yDAUPgLZh9Fg8zDQdfjJP3ZSKtFwSl80bETz/rrKg=="],
 
@@ -865,8 +865,6 @@
 
     "@types/accepts": ["@types/accepts@1.3.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-Pay9fq2lM2wXPWbteBsRAGiWH2hig4ZE2asK+mm7kUzlxRTfL961rj89I6zV/E3PcIkDqyuBEcMxFT7rccugeQ=="],
 
-    "@types/bcryptjs": ["@types/bcryptjs@2.4.6", "", {}, "sha512-9xlo6R2qDs5uixm0bcIqCeMCE6HiQsIyel9KQySStiyqNl2tnj2mP3DX1Nf56MD6KMenNNlBBsy3LJ7gUEQPXQ=="],
-
     "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
 
     "@types/bun": ["@types/bun@1.2.16", "", { "dependencies": { "bun-types": "1.2.16" } }, "sha512-1aCZJ/6nSiViw339RsaNhkNoEloLaPzZhxMOYEa7OzRzO41IGg5n/7I43/ZIAW/c+Q6cT12Vf7fOZOoVIzb5BQ=="],
@@ -1057,7 +1055,7 @@
 
     "basic-ftp": ["basic-ftp@5.0.5", "", {}, "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg=="],
 
-    "bcryptjs": ["bcryptjs@2.4.3", "", {}, "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ=="],
+    "bcryptjs": ["bcryptjs@3.0.2", "", { "bin": { "bcrypt": "bin/bcrypt" } }, "sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog=="],
 
     "before-after-hook": ["before-after-hook@3.0.2", "", {}, "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A=="],
 

--- a/package.json
+++ b/package.json
@@ -64,9 +64,9 @@
     "zod": "3.24.1"
   },
   "dependencies": {
+    "@gouvfr/dsfr": "1.13.2",
     "@~/app.api": "workspace:*",
     "@~/app.core": "workspace:*",
-    "@gouvfr/dsfr": "1.13.2",
     "consola": "3.4.2",
     "dotenv": "16.5.0",
     "hono": "4.8.2",

--- a/packages/~/infra/identite-proconnect/lib/package.json
+++ b/packages/~/infra/identite-proconnect/lib/package.json
@@ -15,7 +15,7 @@
     }
   },
   "dependencies": {
-    "@gouvfr-lasuite/proconnect.core": "0.5.0",
+    "@gouvfr-lasuite/proconnect.core": "0.6.0",
     "@gouvfr-lasuite/proconnect.identite": "0.8.0",
     "@gouvfr-lasuite/proconnect.insee": "0.3.2",
     "@gouvfr-lasuite/proconnect.entreprise": "0.0.0",

--- a/packages/~/organizations/api/package.json
+++ b/packages/~/organizations/api/package.json
@@ -16,7 +16,7 @@
     "@~/organizations.repository": "workspace:*",
     "@~/organizations.ui": "workspace:*",
     "@~/users.repository": "workspace:*",
-    "@gouvfr-lasuite/proconnect.core": "0.5.0",
+    "@gouvfr-lasuite/proconnect.core": "0.6.0",
     "hono": "4.8.2",
     "lodash.sortby": "4.7.0",
     "tailwind-variants": "1.0.0",

--- a/packages/~/organizations/repository/src/get_unverified_domains.ts
+++ b/packages/~/organizations/repository/src/get_unverified_domains.ts
@@ -1,8 +1,6 @@
 //
 
-// TODO: Fix this import after migration - the data is not exported from proconnect.core
-// import most_used_free_email_domains from "@gouvfr-lasuite/proconnect.core/src/data/most-used-free-email-domains";
-const most_used_free_email_domains: string[] = [];
+import { mostUsedFreeEmailDomains as most_used_free_email_domains } from "@gouvfr-lasuite/proconnect.core/data";
 import type { Pagination } from "@~/app.core/schema";
 import {
   schema,


### PR DESCRIPTION
<div align=center><img src="https://media.giphy.com/media/3oKIPnAiaMCws8nOsE/giphy.gif" /></div>

---

## Summary

- Updates `@gouvfr-lasuite/proconnect.core` to v0.6.0
- Replaces hardcoded free email domains array with official `mostUsedFreeEmailDomains` export from the library's data module
- Resolves the TODO comment about the missing import after migration

## Test plan

- [x] All tests pass (175 pass, 0 fail)
- [x] Build completes successfully
- [x] Type checking passes

🤖 Generated with [Claude Code](https://claude.ai/code)