### PR TITLE
♻️ replace direct DB query with GetModerationWithUser repository

### DIFF
--- a/sources/moderations/api/src/:id/$procedures/processed.ts
+++ b/sources/moderations/api/src/:id/$procedures/processed.ts
@@ -7,7 +7,7 @@ import type { IdentiteProconnect_Pg_Context } from "@~/app.middleware/set_identi
 import type { UserInfoVariables_Context } from "@~/app.middleware/set_userinfo";
 import { MODERATION_EVENTS } from "@~/moderations.lib/event";
 import { mark_moderatio_as_rejected } from "@~/moderations.lib/usecase/mark_moderatio_as_rejected";
-import { GetModeration } from "@~/moderations.repository";
+import { GetModerationWithUser } from "@~/moderations.repository";
 import { Hono } from "hono";
 
 //
@@ -20,8 +20,8 @@ export default new Hono<
   async ({ text, req, notFound, var: { identite_pg, userinfo } }) => {
     const { id } = req.valid("param");
 
-    const get_moderation = await GetModeration(identite_pg);
-    const moderation = await get_moderation(id);
+    const get_moderation_with_user = GetModerationWithUser(identite_pg);
+    const moderation = await get_moderation_with_user(id);
 
     if (!moderation) return notFound();
 

--- a/sources/moderations/api/src/:id/$procedures/rejected.ts
+++ b/sources/moderations/api/src/:id/$procedures/rejected.ts
@@ -11,7 +11,7 @@ import { reject_form_schema } from "@~/moderations.lib/schema/rejected.form";
 import { mark_moderation_as } from "@~/moderations.lib/usecase/mark_moderation_as";
 import { RespondToTicket } from "@~/moderations.lib/usecase/RespondToTicket";
 import { SendRejectedMessageToUser } from "@~/moderations.lib/usecase/SendRejectedMessageToUser";
-import { GetModeration, UpdateModerationById } from "@~/moderations.repository";
+import { GetModerationWithUser, UpdateModerationById } from "@~/moderations.repository";
 import { Hono } from "hono";
 import type { ContextType } from "./context";
 
@@ -30,8 +30,8 @@ export default new Hono<ContextType>().patch(
     const { id: moderation_id } = req.valid("param");
     const { message, reason, subject } = req.valid("form");
 
-    const get_moderation = GetModeration(identite_pg);
-    const moderation = await get_moderation(moderation_id);
+    const get_moderation_with_user = GetModerationWithUser(identite_pg);
+    const moderation = await get_moderation_with_user(moderation_id);
     const crisp = CrispApi(crisp_config);
     const update_moderation_by_id = UpdateModerationById({ pg: identite_pg });
     const respond_to_ticket = RespondToTicket();

--- a/sources/moderations/lib/src/context/rejected.ts
+++ b/sources/moderations/lib/src/context/rejected.ts
@@ -3,14 +3,14 @@
 import type { AgentConnect_UserInfo } from "@~/app.middleware/session";
 import type { CrispApi } from "@~/crisp.lib/api";
 import type { IdentiteProconnect_PgDatabase } from "@~/identite-proconnect.database";
-import type { GetModerationDto } from "@~/moderations.repository";
+import type { GetModerationWithUserDto } from "@~/moderations.repository";
 import type { RejectedMessage } from "../schema/rejected.form";
 
 //
 
 export type RejectedModeration_Context = {
   crisp: CrispApi;
-  moderation: GetModerationDto;
+  moderation: GetModerationWithUserDto;
   pg: IdentiteProconnect_PgDatabase;
   reason: string;
   resolve_delay: number;

--- a/sources/moderations/lib/src/usecase/mark_moderatio_as_rejected.ts
+++ b/sources/moderations/lib/src/usecase/mark_moderatio_as_rejected.ts
@@ -5,7 +5,7 @@ import type { AgentConnect_UserInfo } from "@~/app.middleware/session";
 import type { IdentiteProconnect_PgDatabase } from "@~/identite-proconnect.database";
 import {
   UpdateModerationById,
-  type GetModerationDto,
+  type GetModerationWithUserDto,
 } from "@~/moderations.repository";
 import { append_comment } from "../comment_message";
 
@@ -17,7 +17,7 @@ export async function mark_moderatio_as_rejected({
   userinfo,
   reason,
 }: {
-  moderation: GetModerationDto;
+  moderation: GetModerationWithUserDto;
   userinfo: AgentConnect_UserInfo;
   pg: IdentiteProconnect_PgDatabase;
   reason: string;

--- a/sources/moderations/repository/src/GetModeration.test.ts
+++ b/sources/moderations/repository/src/GetModeration.test.ts
@@ -11,7 +11,7 @@ import {
   pg,
 } from "@~/identite-proconnect.database/testing";
 import { beforeAll, beforeEach, expect, test } from "bun:test";
-import { GetModeration } from "./GetModeration";
+import { GetModerationWithUser } from "./GetModerationWithUser";
 
 //
 
@@ -25,8 +25,8 @@ test("get a moderation with minimal fields", async () => {
   await create_adora_pony_user(pg);
   const moderation_id = await create_adora_pony_moderation(pg, { type: "" });
 
-  const get_moderation = GetModeration(pg);
-  const moderation = await get_moderation(moderation_id);
+  const get_moderation_with_user = GetModerationWithUser(pg);
+  const moderation = await get_moderation_with_user(moderation_id);
 
   expect(moderation).toMatchInlineSnapshot(`
     {
@@ -43,7 +43,7 @@ test("get a moderation with minimal fields", async () => {
 });
 
 test("throws NotFoundError when moderation does not exist", async () => {
-  const get_moderation = GetModeration(pg);
+  const get_moderation_with_user = GetModerationWithUser(pg);
 
-  await expect(get_moderation(999999)).rejects.toThrow("Moderation not found.");
+  await expect(get_moderation_with_user(999999)).rejects.toThrow("Moderation not found.");
 });

--- a/sources/moderations/repository/src/GetModerationWithUser.ts
+++ b/sources/moderations/repository/src/GetModerationWithUser.ts
@@ -9,8 +9,8 @@ import { eq } from "drizzle-orm";
 
 //
 
-export function GetModeration(pg: IdentiteProconnect_PgDatabase) {
-  return async function get_moderation(moderation_id: number) {
+export function GetModerationWithUser(pg: IdentiteProconnect_PgDatabase) {
+  return async function get_moderation_with_user(moderation_id: number) {
     const moderation = await pg.query.moderations.findFirst({
       columns: {
         id: true,
@@ -29,5 +29,5 @@ export function GetModeration(pg: IdentiteProconnect_PgDatabase) {
   };
 }
 
-export type GetModerationHandler = ReturnType<typeof GetModeration>;
-export type GetModerationDto = Awaited<ReturnType<GetModerationHandler>>;
+export type GetModerationWithUserHandler = ReturnType<typeof GetModerationWithUser>;
+export type GetModerationWithUserDto = Awaited<ReturnType<GetModerationWithUserHandler>>;

--- a/sources/moderations/repository/src/index.ts
+++ b/sources/moderations/repository/src/index.ts
@@ -1,7 +1,7 @@
 //
 
 export * from "./GetDuplicateModerations";
-export * from "./GetModeration";
+export * from "./GetModerationWithUser";
 export * from "./GetModerationById";
 export * from "./GetModerationForEmail";
 export * from "./GetModerationsByUserId";


### PR DESCRIPTION
Replace direct database query in validate controller with proper repository pattern:
- Rename GetModeration to GetModerationWithUser for clarity
- Use await-to-js pattern for error handling as per CONTRIBUTING.md
- Properly handle NotFoundError to return 404 response
- Rename error variables to avoid naming conflicts (moderation_error, domain_error, join_error)

This follows the established repository pattern and improves code consistency.