### PR TITLE
🐛 Fix expired API token silently showing "no leaders list"

### DIFF
--- a/.release-it-changeset/1776264974-bug.md
+++ b/.release-it-changeset/1776264974-bug.md
@@ -1,0 +1,1 @@
+🐛 Correction d'un problème d'affichage où une error affichée silencieusement aucune liste dirigeant

--- a/sources/web/src/routes/organizations/leaders/index.test.ts
+++ b/sources/web/src/routes/organizations/leaders/index.test.ts
@@ -176,3 +176,48 @@ test("GET /organizations/leaders - retry fails, button still shown for further r
   `);
   expect(mockFetch).toHaveBeenCalledTimes(1);
 });
+
+test("GET /organizations/leaders - expired token shows error message", async () => {
+  const mockFetch = mock(() =>
+    Promise.resolve(
+      new Response(
+        JSON.stringify({
+          errors: [
+            {
+              code: "00103",
+              title: "Jeton expiré",
+              detail: "Votre token est expiré.",
+            },
+          ],
+        }),
+        {
+          status: 401,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+    ),
+  );
+
+  const response = await new Hono()
+    .use(set_fetch(mockFetch))
+    .route("/", app)
+    .request("/?siret=12345678901234", undefined, {
+      ENTREPRISE_API_GOUV_URL: "https://api.entreprise.example.com",
+      ENTREPRISE_API_GOUV_TOKEN: "test-token",
+      HTTP_CLIENT_TIMEOUT: 5000,
+    });
+
+  expect(response.status).toBe(200);
+  expect(await render_html(await response.text())).toMatchInlineSnapshot(
+    `
+      "<button
+        class="disabled:bg-grey-200 disabled:text-grey-425 inline-flex w-fit items-center font-medium no-underline disabled:cursor-not-allowed min-h-8 gap-1 px-3 py-1 text-sm leading-6 text-blue-france hover:bg-grey-50 bg-transparent shadow-[inset_0_0_0_1px_var(--color-grey-200)]"
+        disabled=""
+      >
+        Erreur API — contacter l&#39;équipe tech
+      </button>
+      "
+    `,
+  );
+  expect(mockFetch).toHaveBeenCalledTimes(1);
+});

--- a/sources/web/src/routes/organizations/leaders/index.tsx
+++ b/sources/web/src/routes/organizations/leaders/index.tsx
@@ -12,6 +12,8 @@ import lodash_sortby from "lodash.sortby";
 import { match, P } from "ts-pattern";
 import { z } from "zod";
 
+class FatalError extends Error {}
+
 export default new Hono<FetchVariablesContext & AppEnvContext>().get(
   "/",
   zValidator(
@@ -31,6 +33,13 @@ export default new Hono<FetchVariablesContext & AppEnvContext>().get(
     const doc = await load_leaders({ siret, fetch, useRetry, env });
 
     return match(doc)
+      .with(P.instanceOf(FatalError), () =>
+        html(
+          <button class={button({ size: "sm", type: "tertiary" })} disabled>
+            Erreur API — contacter l'équipe tech
+          </button>,
+        ),
+      )
       .with(P.instanceOf(Error), () =>
         html(
           <button
@@ -60,9 +69,9 @@ export default new Hono<FetchVariablesContext & AppEnvContext>().get(
       )
       .otherwise(() =>
         html(
-          <a class={button({ size: "sm", type: "tertiary" })}>
+          <button class={button({ size: "sm", type: "tertiary" })} disabled>
             Pas de liste des dirigeants
-          </a>,
+          </button>,
         ),
       );
   },
@@ -115,6 +124,11 @@ async function load_leaders({
   consola.info(
     `  -->> ${"GET"} ${url} ${response.status} ${response.statusText}${retryLabel}`,
   );
+
+  if (!response.ok) {
+    consola.error(`API error ${response.status}:`, await response.text());
+    return new FatalError(`HTTP ${response.status}`);
+  }
 
   const { data } =
     (await response.json()) as Entreprise_API_Association_Response;


### PR DESCRIPTION
- fixes the styling of the ‘no leader list’ button, which looked clickable when it wasn’t!
- creation of a specific error so that persistent errors are not hidden 