### PR TITLE
 ✨ response-templates: add delete action 

### DIFF
--- a/sources/web/src/routes.d.ts
+++ b/sources/web/src/routes.d.ts
@@ -410,20 +410,17 @@ declare const app: import("hono/hono-base").HonoBase<
               >
             | import("hono/types").MergeSchemaPath<
                 {
-                  "/message": {
+                  "/reason/:response_id": {
                     $get: {
                       input: {
                         param: {
                           id: string;
-                        };
-                      } & {
-                        query: {
-                          reason: string;
+                          response_id: string;
                         };
                       };
-                      output: {};
-                      outputFormat: string;
-                      status: import("hono/utils/http-status").StatusCode;
+                      output: string;
+                      outputFormat: "text";
+                      status: import("hono/utils/http-status").ContentfulStatusCode;
                     };
                   };
                 } & {
@@ -1154,6 +1151,19 @@ declare const app: import("hono/hono-base").HonoBase<
             output: "";
             outputFormat: "text";
             status: 200;
+          };
+        };
+      } & {
+        "/:id": {
+          $delete: {
+            input: {
+              param: {
+                id: string;
+              };
+            };
+            output: {};
+            outputFormat: string;
+            status: import("hono/utils/http-status").StatusCode;
           };
         };
       },

--- a/sources/web/src/routes/response-templates/detail.page.tsx
+++ b/sources/web/src/routes/response-templates/detail.page.tsx
@@ -25,7 +25,8 @@ export default function DetailPage({
   const is_new = !template;
   const form_action = is_new
     ? urls["response-templates"].$url().pathname
-    : `${urls["response-templates"].$url().pathname}/${template.id}`;
+    : urls["response-templates"][":id"].$url({ param: { id: template.id } })
+        .pathname;
 
   const { base: alert_base } = alert({ intent: "success" });
 
@@ -36,13 +37,24 @@ export default function DetailPage({
           <p>Template créé !</p>
         </div>
       )}
-      <a
-        href={urls["response-templates"].$url().pathname}
-        class={button({ intent: "ghost", size: "sm", class: "mb-6" })}
-      >
-        <Svg name="arrow-go-back" />
-        Retour à la liste
-      </a>
+      <div class="mb-6 flex items-center justify-between">
+        <a
+          href={urls["response-templates"].$url().pathname}
+          class={button({ intent: "ghost", size: "sm" })}
+        >
+          <Svg name="arrow-go-back" />
+          Retour à la liste
+        </a>
+        {!is_new && (
+          <button
+            class={button({ intent: "danger", size: "sm" })}
+            hx-delete={form_action}
+            hx-confirm="Supprimer ce template ?"
+          >
+            Supprimer
+          </button>
+        )}
+      </div>
 
       <form
         {...(is_new

--- a/sources/web/src/routes/response-templates/index.test.ts
+++ b/sources/web/src/routes/response-templates/index.test.ts
@@ -63,3 +63,19 @@ test("GET /response-templates/:id returns detail page", async () => {
   expect(html).toContain(html_encode`${template.label}`.toString());
   expect(html).toContain("Retour à la liste");
 });
+
+test("DELETE /response-templates/:id deletes template and redirects to list", async () => {
+  const template = await insert_central_administration_response(hyyyper_pglite);
+
+  const testing_app = await make_app();
+  const response = await testing_app.request(`/${template.id}`, {
+    method: "DELETE",
+  });
+
+  expect(response.status).toBe(200);
+  expect(response.headers.get("HX-Redirect")).toBe("/response-templates");
+
+  const remaining = await testing_app.request("/");
+  const html = await remaining.text();
+  expect(html).not.toContain(html_encode`${template.label}`.toString());
+});

--- a/sources/web/src/routes/response-templates/index.tsx
+++ b/sources/web/src/routes/response-templates/index.tsx
@@ -99,4 +99,14 @@ export default new Hono<AppContext>()
         }),
       });
     },
-  );
+  )
+  .delete("/:id", async function DELETE({ req, var: { hyyyper_pg } }) {
+    const id = parseInt(req.param("id"), 10);
+    await hyyyper_pg
+      .delete(schema.response_templates)
+      .where(eq(schema.response_templates.id, id));
+    return new Response(null, {
+      status: 200,
+      headers: { "HX-Redirect": "/response-templates" },
+    });
+  });


### PR DESCRIPTION
**Problem**

There was no way to remove a response template once created, forcing manual DB intervention to clean up stale or incorrect entries.

**Proposal**

Add a DELETE /:id route that removes the template and responds with HX-Redirect to navigate back to the list. Wire a danger-intent delete button into the detail page header, guarded by hx-confirm, and visible only on existing templates.