### PR TITLE
🐛 seed: fix glob silently skipping 6 response templates

### DIFF
--- a/.release-it-changeset/1778591728-fix-seed-glob-response-templates.md
+++ b/.release-it-changeset/1778591728-fix-seed-glob-response-templates.md
@@ -1,0 +1,3 @@
+🐛 Correction du seed des modèles de réponse
+
+Le pattern glob `[!index]*.ts` était interprété comme une classe de caractères et excluait silencieusement 6 modèles de réponse du seed. Ces 6 templates manquants sont désormais correctement chargés et insérés en base de données.

--- a/sources/hyyyperbase/bin/seed/0000_response_types/lib.test.ts
+++ b/sources/hyyyperbase/bin/seed/0000_response_types/lib.test.ts
@@ -1,7 +1,12 @@
 //
 
 import { describe, expect, setSystemTime, test } from "bun:test";
+import { glob } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { load_templates } from "./lib";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 //
 
@@ -9,8 +14,15 @@ setSystemTime(new Date("2026-04-13T15:04:15.185Z"));
 const response_files = await load_templates();
 
 describe("seed:0000_response_types", () => {
-  test("loads old 28 legacy response templates", async () => {
-    expect(response_files).toHaveLength(30);
+  test("loads all response template files", async () => {
+    const files = await Array.fromAsync(
+      glob(join(__dirname, "responses", "*.ts")),
+    );
+    const response_files_count = files.filter(
+      (f) => !f.endsWith(".test.ts") && !f.endsWith("index.ts"),
+    ).length;
+    expect(response_files).toHaveLength(response_files_count);
+    expect(response_files).toHaveLength(36);
   });
 
   test("Utilisateur possédant déjà un compte ProConnect", async () => {

--- a/sources/hyyyperbase/bin/seed/0000_response_types/lib.ts
+++ b/sources/hyyyperbase/bin/seed/0000_response_types/lib.ts
@@ -23,11 +23,12 @@ type TemplateModule = {
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export async function load_templates(): Promise<ResponseTemplateInsert[]> {
-  const pattern = join(__dirname, "responses", "[!index]*.ts");
+  const pattern = join(__dirname, "responses", "*.ts");
   const files: ResponseTemplateInsert[] = [];
 
   for await (const file of glob(pattern)) {
     if (file.endsWith(".test.ts")) continue;
+    if (file.endsWith("index.ts")) continue;
 
     const module: TemplateModule = await import(file);
 


### PR DESCRIPTION
**Problem**

The glob pattern `[!index]*.ts` is a character class, not a filename exclusion. It silently drops any file starting with i, n, d, e, or x — which excluded 6 valid templates (domain_name_not_found, enseignement_agricole, evidence_between_chosen_org_and_domain_email_org, existing_domain_name, name_incorrectly_entered, non_teaching_agent) from every seed run.

**Proposal**

Replace the broken pattern with `*.ts` and explicitly skip `.test.ts` and `index.ts` files. Add a test that counts loadable templates against the actual files on disk so this class of regression is caught immediately.