### PR TITLE
🐛 cache: fix immutable middleware never setting cache-control header

### DIFF
--- a/.release-it-changeset/1778597520-fix-cache-control-assets.md
+++ b/.release-it-changeset/1778597520-fix-cache-control-assets.md
@@ -1,0 +1,3 @@
+🐛 Correction de l'en-tête Cache-Control sur les assets statiques
+
+L'en-tête `Cache-Control: public, max-age=31536000, immutable` n'était jamais envoyé sur les ressources statiques en production. Le middleware `cache_immutable` vérifiait `c.finalized` après `serveStatic`, ce qui court-circuitait systématiquement l'ajout de l'en-tête. La note de version associée a été perdue lors d'une manipulation de l'historique git, d'où cette nouvelle release.

--- a/sources/web/src/middleware/cache/cache_immutable.ts
+++ b/sources/web/src/middleware/cache/cache_immutable.ts
@@ -8,8 +8,8 @@ import { createMiddleware } from "hono/factory";
 export const cache_immutable = createMiddleware<AppEnvContext>(
   async function immutable_middleware(c, next) {
     await next();
-    if (c.finalized) return;
     if (c.env.NODE_ENV === "development") return;
+    if (!c.res.ok) return;
     c.header("cache-control", "public,max-age=31536000,immutable");
   },
 );


### PR DESCRIPTION
**Problem**

`cache_immutable` called `if (c.finalized) return` immediately after
`await next()`. After `serveStatic` serves a file it marks the context
as finalized, so the guard always triggered and `Cache-Control` was
never written — even in production.

**Proposal**

Drop the `c.finalized` guard and replace it with `if (!c.res.ok) return`
so successful (2xx) responses get `public,max-age=31536000,immutable`
while 4xx/5xx responses are left uncached.

Better than https://github.com/proconnect-gouv/hyyypertool/pull/1601