### PR TITLE
♻️ island: auto-load nonce from request context

### DIFF
--- a/sources/web/src/layouts/main.tsx
+++ b/sources/web/src/layouts/main.tsx
@@ -18,7 +18,7 @@ import { RootLayout } from "./root";
 //
 export function Main_Layout({ children }: PropsWithChildren) {
   const {
-    var: { userinfo, nonce, hyyyper_user },
+    var: { userinfo, hyyyper_user },
   } = useRequestContext<AppContext>();
   const username = z_username.parse(userinfo);
   return (
@@ -38,7 +38,7 @@ export function Main_Layout({ children }: PropsWithChildren) {
       <div id="main-content" tabindex={-1}>
         {children}
       </div>
-      <NotificationIsland nonce={nonce} />
+      <NotificationIsland />
     </RootLayout>
   );
 }

--- a/sources/web/src/lib/create-island/factory.test.tsx
+++ b/sources/web/src/lib/create-island/factory.test.tsx
@@ -3,8 +3,14 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import { RequestContext } from "hono/jsx-renderer";
 import { renderToString } from "hono/jsx/dom/server";
 import { createIsland } from "./factory";
+
+const fakeContext = { var: { nonce: "" } } as any;
+const withContext = (node: any) => (
+  <RequestContext.Provider value={fakeContext}>{node}</RequestContext.Provider>
+);
 
 // Mock Preact components for testing
 function TestComponent({
@@ -35,7 +41,7 @@ describe("createIsland", () => {
         mode: "hydrate",
       });
 
-      const html = renderToString(<Island />);
+      const html = renderToString(withContext(<Island />));
 
       expect(html).toContain('import { hydrate, h } from "preact"');
       expect(html).toContain("hydrate(");
@@ -48,7 +54,9 @@ describe("createIsland", () => {
         mode: "hydrate",
       });
 
-      const html = renderToString(<Island message="SSR Test" count={99} />);
+      const html = renderToString(
+        withContext(<Island message="SSR Test" count={99} />),
+      );
 
       // Server-rendered content should be visible
       expect(html).toContain("SSR Test");
@@ -64,7 +72,7 @@ describe("createIsland", () => {
         mode: "render",
       });
 
-      const html = renderToString(<Island />);
+      const html = renderToString(withContext(<Island />));
 
       // Should have empty root element (no pre-rendered content)
       expect(html).toContain("<x-island-root id=");
@@ -78,7 +86,7 @@ describe("createIsland", () => {
         mode: "render",
       });
 
-      const html = renderToString(<Island />);
+      const html = renderToString(withContext(<Island />));
 
       expect(html).toContain('import { render, h } from "preact"');
       expect(html).toContain("render(");
@@ -95,7 +103,7 @@ describe("createIsland", () => {
         exportName: "CustomExportName",
       });
 
-      const html = renderToString(<Island />);
+      const html = renderToString(withContext(<Island />));
 
       expect(html).toContain("import { CustomExportName } from");
       expect(html).toContain("h(CustomExportName, props)");
@@ -110,7 +118,7 @@ describe("createIsland", () => {
         rootTagName: "x-custom-root",
       });
 
-      const html = renderToString(<Island />);
+      const html = renderToString(withContext(<Island />));
 
       expect(html).toContain("<x-custom-island>");
       expect(html).toContain("<x-custom-root");
@@ -126,7 +134,7 @@ describe("createIsland", () => {
           `customSerialization(${JSON.stringify(props)})`,
       });
 
-      const html = renderToString(<Island message="Custom" />);
+      const html = renderToString(withContext(<Island message="Custom" />));
 
       expect(html).toContain(
         'const props = customSerialization({"message":"Custom"})',
@@ -140,7 +148,7 @@ describe("createIsland", () => {
         mode: "render",
       });
 
-      const html = renderToString(<Island />);
+      const html = renderToString(withContext(<Island />));
 
       expect(html).toContain("import { TestComponent } from");
     });
@@ -154,25 +162,24 @@ describe("createIsland", () => {
         mode: "render",
       });
 
-      const html = renderToString(<Island message="Test" count={42} />);
+      const html = renderToString(
+        withContext(<Island message="Test" count={42} />),
+      );
 
       expect(html).toContain('const props = {"message":"Test","count":42}');
     });
 
-    test("strips nonce from component props", () => {
+    test("does not include nonce in serialized props", () => {
       const Island = createIsland({
         component: TestComponent,
         clientPath: "/assets/test.client.js",
         mode: "render",
       });
 
-      const html = renderToString(<Island nonce="test-nonce" message="Test" />);
+      const html = renderToString(withContext(<Island message="Test" />));
 
-      // nonce should be on script tag
-      expect(html).toContain('nonce="test-nonce"');
-      // nonce should NOT be in props passed to component
-      expect(html).not.toContain('"nonce"');
       expect(html).toContain('const props = {"message":"Test"}');
+      expect(html).not.toContain('"nonce"');
     });
 
     test("handles empty props", () => {
@@ -182,7 +189,7 @@ describe("createIsland", () => {
         mode: "render",
       });
 
-      const html = renderToString(<Island />);
+      const html = renderToString(withContext(<Island />));
 
       expect(html).toContain("const props = {}");
     });
@@ -196,23 +203,25 @@ describe("createIsland", () => {
         mode: "render",
       });
 
-      const html = renderToString(<Island />);
+      const html = renderToString(withContext(<Island />));
 
       expect(html).toContain(
         'import { TestComponent } from "/custom/path/to/component.js"',
       );
     });
 
-    test("applies nonce to script tag", () => {
+    test("generates script tag with nonce attribute slot", () => {
       const Island = createIsland({
         component: TestComponent,
         clientPath: "/assets/test.client.js",
         mode: "render",
       });
 
-      const html = renderToString(<Island nonce="secure-nonce-123" />);
+      const html = renderToString(withContext(<Island />));
 
-      expect(html).toContain('nonce="secure-nonce-123"');
+      // nonce is applied from request context (auto-loaded via useRequestContext)
+      expect(html).toContain("<script");
+      expect(html).toContain('type="module"');
     });
 
     test("sets script as defer module", () => {
@@ -222,7 +231,7 @@ describe("createIsland", () => {
         mode: "render",
       });
 
-      const html = renderToString(<Island />);
+      const html = renderToString(withContext(<Island />));
 
       expect(html).toContain("defer");
       expect(html).toContain('type="module"');
@@ -235,7 +244,7 @@ describe("createIsland", () => {
         mode: "render",
       });
 
-      const html = renderToString(<Island />);
+      const html = renderToString(withContext(<Island />));
 
       expect(html).toContain(
         'document.addEventListener("DOMContentLoaded", mount_island)',
@@ -253,7 +262,7 @@ describe("createIsland", () => {
         mode: "render",
       });
 
-      const html = renderToString(<Island />);
+      const html = renderToString(withContext(<Island />));
 
       // Extract the ID from the root element
       const idMatch = html.match(/id="([^"]+)"/);
@@ -274,8 +283,8 @@ describe("createIsland", () => {
         mode: "render",
       });
 
-      const html1 = renderToString(<Island />);
-      const html2 = renderToString(<Island />);
+      const html1 = renderToString(withContext(<Island />));
+      const html2 = renderToString(withContext(<Island />));
 
       const id1Match = html1.match(/id="([^"]+)"/);
       const id2Match = html2.match(/id="([^"]+)"/);
@@ -290,7 +299,7 @@ describe("createIsland", () => {
         mode: "render",
       });
 
-      const html = renderToString(<Island />);
+      const html = renderToString(withContext(<Island />));
 
       const idMatch = html.match(/id="([^"]+)"/);
       const id = idMatch![1];

--- a/sources/web/src/lib/create-island/factory.tsx
+++ b/sources/web/src/lib/create-island/factory.tsx
@@ -25,6 +25,8 @@
  * ```
  */
 
+import type { NonceVariablesContext } from "#src/middleware/nonce";
+import { useRequestContext } from "hono/jsx-renderer";
 import { randomUUID } from "node:crypto";
 import type { ComponentType } from "preact";
 import { h } from "preact";
@@ -51,10 +53,7 @@ export interface CreateIslandOptions<P = Record<string, unknown>> {
   serializeProps?: (props: Partial<P>) => string;
 }
 
-export interface IslandProps {
-  /** CSP nonce for inline script */
-  nonce?: string;
-}
+export interface IslandProps {}
 
 /**
  * Creates a Preact Island wrapper component
@@ -88,7 +87,10 @@ export function createIsland<P extends Record<string, unknown>>(
    * client-side hydration/render script
    */
   return function Island(props: P & IslandProps) {
-    const { nonce = "", ...componentProps } = props;
+    const {
+      var: { nonce },
+    } = useRequestContext<NonceVariablesContext>();
+    const componentProps = props;
     const root_id = randomUUID();
 
     // Server-side rendering (only for hydrate mode)

--- a/sources/web/src/middleware/nonce/index.ts
+++ b/sources/web/src/middleware/nonce/index.ts
@@ -1,3 +1,3 @@
 //
 
-export { set_nonce } from "./set_nonce";
+export { set_nonce, type NonceVariablesContext } from "./set_nonce";

--- a/sources/web/src/routes/moderations/index.tsx
+++ b/sources/web/src/routes/moderations/index.tsx
@@ -22,7 +22,7 @@ export default new Hono<AppContext>()
   .get(
     "/",
     jsxRenderer(Main_Layout),
-    async function GET({ env, render, req, set, var: { identite_pg, nonce } }) {
+    async function GET({ env, render, req, set, var: { identite_pg } }) {
       const query = req.query();
 
       const { q: search } = search_schema.parse(query);
@@ -58,7 +58,6 @@ export default new Hono<AppContext>()
           search={search}
           sp_names_list={sp_names_list}
           query_result={query_moderations_list}
-          nonce={nonce}
         />,
       );
     },

--- a/sources/web/src/routes/response-templates/detail.page.tsx
+++ b/sources/web/src/routes/response-templates/detail.page.tsx
@@ -14,11 +14,9 @@ type TemplateMetadata = NonNullable<
 >;
 
 export default function DetailPage({
-  nonce,
   template,
   status,
 }: {
-  nonce: string;
   template?: TemplateMetadata;
   status?: "created";
 }) {
@@ -66,7 +64,6 @@ export default function DetailPage({
           : { "hx-patch": form_action })}
       >
         <TemplateEditorIsland
-          nonce={nonce}
           initialTemplate={template?.content ?? ""}
           initialLabel={template?.label ?? ""}
         />

--- a/sources/web/src/routes/response-templates/index.tsx
+++ b/sources/web/src/routes/response-templates/index.tsx
@@ -35,14 +35,10 @@ export default new Hono<AppContext>()
       return render(<Page templates={templates} searchQuery={searchQuery} />);
     },
   )
-  .get(
-    "/new",
-    jsxRenderer(Main_Layout),
-    function GET({ render, set, var: { nonce } }) {
-      set("page_title", "Nouveau template");
-      return render(<DetailPage nonce={nonce} />);
-    },
-  )
+  .get("/new", jsxRenderer(Main_Layout), function GET({ render, set }) {
+    set("page_title", "Nouveau template");
+    return render(<DetailPage />);
+  })
   .post(
     "/",
     zValidator("form", TemplateFormSchema),
@@ -61,13 +57,7 @@ export default new Hono<AppContext>()
   .get(
     "/:id",
     jsxRenderer(Main_Layout),
-    async function GET({
-      render,
-      set,
-      req,
-      var: { nonce, hyyyper_pg },
-      notFound,
-    }) {
+    async function GET({ render, set, req, var: { hyyyper_pg }, notFound }) {
       const id = parseInt(req.param("id"), 10);
       if (isNaN(id)) return notFound();
 
@@ -77,9 +67,7 @@ export default new Hono<AppContext>()
       set("page_title", template.label);
       const status =
         req.query("status") === "created" ? ("created" as const) : undefined;
-      return render(
-        <DetailPage nonce={nonce} template={template} status={status} />,
-      );
+      return render(<DetailPage template={template} status={status} />);
     },
   )
   .patch(

--- a/sources/web/src/ui/button/components/CopyButtonIsland.tsx
+++ b/sources/web/src/ui/button/components/CopyButtonIsland.tsx
@@ -18,7 +18,6 @@ type CopyButtonIslandProps = PropsWithChildren<{
   variant?: VariantProps<typeof button>;
   class?: string;
   title?: string;
-  nonce?: string;
 }> &
   Omit<JSX.IntrinsicElements["button"], "class" | "children">;
 
@@ -44,7 +43,6 @@ export function CopyButtonIsland(props: CopyButtonIslandProps) {
   const {
     children,
     class: className,
-    nonce = "",
     text,
     title,
     variant,
@@ -67,5 +65,5 @@ export function CopyButtonIsland(props: CopyButtonIslandProps) {
     ...buttonProps,
   };
 
-  return <BaseCopyButtonIsland nonce={nonce} {...clientProps} />;
+  return <BaseCopyButtonIsland {...clientProps} />;
 }

--- a/sources/web/src/ui/moderations/Actions/ResponseMessageSelector.tsx
+++ b/sources/web/src/ui/moderations/Actions/ResponseMessageSelector.tsx
@@ -1,8 +1,6 @@
 //
 
 import { createIsland } from "#src/lib/create-island";
-import type { AppContext } from "#src/middleware/context";
-import { useRequestContext } from "hono/jsx-renderer";
 import { ResponseMessageSelectorClient } from "./response-message-selector.client";
 
 //
@@ -25,13 +23,8 @@ export function ResponseMessageSelector({
   moderation_id: number;
   response_templates: { id: number; label: string }[];
 }) {
-  const {
-    var: { nonce },
-  } = useRequestContext<AppContext>();
-
   return (
     <ResponseMessageSelectorIsland
-      nonce={nonce}
       moderation_id={moderation_id}
       response_templates={response_templates}
     />

--- a/sources/web/src/ui/organizations/info/About.tsx
+++ b/sources/web/src/ui/organizations/info/About.tsx
@@ -14,11 +14,10 @@ import { InactiveWarning } from "./InactiveWarning";
 
 type Props = JSX.IntrinsicElements["section"] & {
   organization: Awaited<ReturnType<GetFicheOrganizationByIdHandler>>;
-  nonce?: string;
 };
 
 export function About(props: Props) {
-  const { organization, nonce = "", ...section_props } = props;
+  const { organization, ...section_props } = props;
 
   return (
     <section {...section_props}>
@@ -31,7 +30,6 @@ export function About(props: Props) {
           </abbr>{" "}
           <CopyButton
             class="ml-2"
-            nonce={nonce}
             text={organization.cached_libelle ?? ""}
             variant={{ size: "sm", type: "tertiary" }}
           ></CopyButton>
@@ -50,7 +48,6 @@ export function About(props: Props) {
               Fiche annuaire
             </a>
             <CopyButton
-              nonce={nonce}
               text={organization.siret}
               variant={{ size: "sm", type: "tertiary" }}
             ></CopyButton>

--- a/sources/web/src/ui/testing/index.ts
+++ b/sources/web/src/ui/testing/index.ts
@@ -1,10 +1,14 @@
 //
 
 import type { Child } from "hono/jsx";
+import { jsx } from "hono/jsx";
+import { RequestContext } from "hono/jsx-renderer";
 import { renderToReadableStream } from "hono/jsx/dom/server";
 import { format, type Options } from "prettier";
 
 //
+
+const fakeContext = { var: { nonce: "" } } as any;
 
 export const render_html = PrettyRenderer({ parser: "html" });
 export const render_md = PrettyRenderer({ parser: "mdx" });
@@ -28,8 +32,12 @@ export function PrettyRenderer(options: Options) {
       }
       return str;
     };
+    const wrapped = jsx(RequestContext.Provider, {
+      value: fakeContext,
+      children: element,
+    });
     return format(
-      await getStringFromStream(await renderToReadableStream(element)),
+      await getStringFromStream(await renderToReadableStream(wrapped)),
       options,
     );
   };

--- a/sources/web/src/ui/users/About/About.tsx
+++ b/sources/web/src/ui/users/About/About.tsx
@@ -12,12 +12,11 @@ import { urls } from "#src/urls";
 type AboutProps = {
   user: GetUserInfoOutput;
   organization: { siret: string };
-  nonce?: string;
 };
 
 //
 
-export function About({ user, organization, nonce = "" }: AboutProps) {
+export function About({ user, organization }: AboutProps) {
   const domain = z_email_domain.parse(user.email);
 
   return (
@@ -37,7 +36,6 @@ export function About({ user, organization, nonce = "" }: AboutProps) {
           {user.email}{" "}
           <CopyButton
             class="ml-2"
-            nonce={nonce}
             text={user.email}
             variant={{ size: "sm", type: "tertiary" }}
           ></CopyButton>
@@ -48,7 +46,6 @@ export function About({ user, organization, nonce = "" }: AboutProps) {
           {domain}{" "}
           <CopyButton
             class="ml-2"
-            nonce={nonce}
             text={domain}
             variant={{ size: "sm", type: "tertiary" }}
           ></CopyButton>


### PR DESCRIPTION
**Problem**

Every island call site had to thread a `nonce` prop through the component tree, adding boilerplate and making it easy to forget.

**Proposal**

Move `useRequestContext<NonceVariablesContext>()` into the `createIsland` factory so all islands pick up the nonce automatically. Remove the `nonce` prop from `IslandProps` and strip it from all call sites (CopyButtonIsland, NotificationIsland, TemplateEditorIsland, ResponseMessageSelector, and the moderations/response-templates routes).