### PR TITLE
✨ moderations: make default sort order explicit

### DIFF
--- a/.release-it-changeset/1779100107-default-sort-created-asc.md
+++ b/.release-it-changeset/1779100107-default-sort-created-asc.md
@@ -1,0 +1,3 @@
+✨ Tri par date de création explicite par défaut
+
+La recherche par défaut inclut désormais `sort:created-asc` afin de rendre explicite l'ordre de tri appliqué. Le filtre par défaut est maintenant `is:pending -type:non_verified_domain sort:created-asc`.

--- a/sources/web/src/routes/moderations/context.test.ts
+++ b/sources/web/src/routes/moderations/context.test.ts
@@ -5,7 +5,7 @@ import { search_schema } from "./context";
 
 //
 
-test("SearchSchema > empty object (default q=is:pending -type:non_verified_domain)", () => {
+test("SearchSchema > empty object (default q=is:pending -type:non_verified_domain sort:created-asc)", () => {
   const { q: search } = search_schema.parse({});
 
   expect(search).toEqual({
@@ -15,7 +15,7 @@ test("SearchSchema > empty object (default q=is:pending -type:non_verified_domai
     search_email: "",
     search_moderated_by: "",
     search_siret: "",
-    search_sort: "",
+    search_sort: "created-asc",
     search_status: "",
     exclude_email: "",
     exclude_moderated_by: "",

--- a/sources/web/src/routes/moderations/context.ts
+++ b/sources/web/src/routes/moderations/context.ts
@@ -14,7 +14,7 @@ export const MODERATION_TABLE_PAGE_ID = "moderation_table_page";
 export const search_schema = z.object({
   q: z
     .string()
-    .default("is:pending -type:non_verified_domain ")
+    .default("is:pending -type:non_verified_domain sort:created-asc")
     .transform(parse_q),
 });
 


### PR DESCRIPTION
**Problem**

The default sort applied by the query (`
asc created_at`) was not reflected
in the default query string, making the behaviour implicit and invisible
in the URL.

**Proposal**

Add `sort:created-asc` to the default filter so the sort is explicit
in the URL from the first page load.