### PR TITLE
🔧 rate-limit: add RATE_LIMIT_POINTS env var with 120 default

### DIFF
--- a/.release-it-changeset/1779350815-rate-limit-points-env-var.md
+++ b/.release-it-changeset/1779350815-rate-limit-points-env-var.md
@@ -1,0 +1,3 @@
+🔧 Limite de débit configurable via variable d'environnement
+
+Le seuil de requêtes autorisées par la limite de débit est désormais configurable via la variable d'environnement `RATE_LIMIT_POINTS` (valeur par défaut : 120).

--- a/sources/web/src/config/env.ts
+++ b/sources/web/src/config/env.ts
@@ -72,6 +72,7 @@ export const app_env = z
       .enum(["development", "production", "test"])
       .default("development"),
     POLL_INTERVAL: z.coerce.number().default(11),
+    RATE_LIMIT_POINTS: z.coerce.number().default(120),
     PORT: z.coerce.number().default(3000),
     PROCONNECT_IDENTITE_DATABASE_URL: z
       .url()

--- a/sources/web/src/routes/index.ts
+++ b/sources/web/src/routes/index.ts
@@ -44,6 +44,7 @@ const {
   FEATURE_RATE_LIMIT_BY_IP,
   HYYYPERBASE_DATABASE_URL,
   PROCONNECT_IDENTITE_DATABASE_URL,
+  RATE_LIMIT_POINTS,
 } = app_env.parse(process.env);
 
 const rate_limit_pool = new pg.Pool({
@@ -59,7 +60,7 @@ const app = new Hono<{ Bindings: AppEnv }>()
   // .use(compress())
   .use(
     FEATURE_RATE_LIMIT_BY_IP
-      ? rate_limit({ storeClient: rate_limit_pool })
+      ? rate_limit({ points: RATE_LIMIT_POINTS, storeClient: rate_limit_pool })
       : (_, next) => next(),
   )
   .use(set_sentry())


### PR DESCRIPTION
**Problem**

The rate limit point threshold was hardcoded to 60, making it impossible to tune without a code change.

**Proposal**

Expose RATE_LIMIT_POINTS as a configurable env var (default 120) and pass it through to the middleware at startup.