### PR TITLE
✨ create-island: add children support

### DIFF
--- a/sources/web/src/lib/create-island/factory.test.tsx
+++ b/sources/web/src/lib/create-island/factory.test.tsx
@@ -28,6 +28,21 @@ function TestComponent({
   );
 }
 
+function WithChildrenComponent({
+  label,
+  children,
+}: {
+  label?: string;
+  children?: import("preact").ComponentChildren;
+}) {
+  return (
+    <div>
+      {label && <span>{label}</span>}
+      <div class="slot">{children}</div>
+    </div>
+  );
+}
+
 function NoPropsComponent() {
   return <div>No props</div>;
 }
@@ -272,6 +287,65 @@ describe("createIsland", () => {
 
       // Script should reference the same ID
       expect(html).toContain(`document.getElementById("${rootId}")`);
+    });
+  });
+
+  describe("children support", () => {
+    test("passes children to SSR in hydrate mode", () => {
+      const Island = createIsland({
+        component: WithChildrenComponent,
+        clientPath: "/assets/test.client.js",
+        mode: "hydrate",
+      });
+
+      const html = renderToString(
+        withContext(
+          <Island label="Parent">
+            <p>child content</p>
+          </Island>,
+        ),
+      );
+
+      expect(html).toContain("child content");
+      expect(html).toContain("Parent");
+    });
+
+    test("does not serialize children in client script", () => {
+      const Island = createIsland({
+        component: WithChildrenComponent,
+        clientPath: "/assets/test.client.js",
+        mode: "render",
+      });
+
+      const html = renderToString(
+        withContext(
+          <Island label="Parent">
+            <p>child content</p>
+          </Island>,
+        ),
+      );
+
+      expect(html).toContain('const props = {"label":"Parent"}');
+      expect(html).not.toContain('"children"');
+    });
+
+    test("handles island with only children and no other props", () => {
+      const Island = createIsland({
+        component: WithChildrenComponent,
+        clientPath: "/assets/test.client.js",
+        mode: "render",
+      });
+
+      const html = renderToString(
+        withContext(
+          <Island>
+            <span>only child</span>
+          </Island>,
+        ),
+      );
+
+      expect(html).toContain("const props = {}");
+      expect(html).not.toContain('"children"');
     });
   });
 

--- a/sources/web/src/lib/create-island/factory.test.tsx
+++ b/sources/web/src/lib/create-island/factory.test.tsx
@@ -197,6 +197,24 @@ describe("createIsland", () => {
       expect(html).not.toContain('"nonce"');
     });
 
+    test("escapes </script> sequences in prop values to prevent script injection", () => {
+      const Island = createIsland({
+        component: TestComponent,
+        clientPath: "/assets/test.client.js",
+        mode: "render",
+      });
+
+      const html = renderToString(
+        withContext(
+          <Island message={'</script><script>alert(1)//'} />,
+        ),
+      );
+
+      // prop value must be Unicode-escaped, not raw — raw </script> would break the script block
+      expect(html).not.toContain('"message":"</script>');
+      expect(html).toContain('"message":"\\u003c/script\\u003e');
+    });
+
     test("handles empty props", () => {
       const Island = createIsland({
         component: NoPropsComponent,

--- a/sources/web/src/lib/create-island/factory.test.tsx
+++ b/sources/web/src/lib/create-island/factory.test.tsx
@@ -205,9 +205,7 @@ describe("createIsland", () => {
       });
 
       const html = renderToString(
-        withContext(
-          <Island message={'</script><script>alert(1)//'} />,
-        ),
+        withContext(<Island message={"</script><script>alert(1)//"} />),
       );
 
       // prop value must be Unicode-escaped, not raw — raw </script> would break the script block
@@ -364,6 +362,39 @@ describe("createIsland", () => {
 
       expect(html).toContain("const props = {}");
       expect(html).not.toContain('"children"');
+    });
+  });
+
+  describe("nested islands", () => {
+    test("server > client > server > client > text", () => {
+      // outer island (render mode, no SSR) wraps an inner island as VNode children
+      // inner island (hydrate mode) receives string children and SSR-renders them
+      const InnerIsland = createIsland({
+        component: WithChildrenComponent,
+        clientPath: "/assets/inner.client.js",
+        mode: "hydrate",
+      });
+
+      const OuterIsland = createIsland({
+        component: NoPropsComponent,
+        clientPath: "/assets/outer.client.js",
+        mode: "render",
+      });
+
+      const html = renderToString(
+        withContext(
+          <OuterIsland>
+            <InnerIsland label="inner-label">leaf text</InnerIsland>
+          </OuterIsland>,
+        ),
+      );
+
+      // server: inner island SSR-renders its Preact component — text is in the HTML
+      expect(html).toContain("inner-label");
+      expect(html).toContain("leaf text");
+
+      // client: inner island script carries the serialized children for hydration
+      expect(html).toContain('"children":"leaf text"');
     });
   });
 

--- a/sources/web/src/lib/create-island/factory.tsx
+++ b/sources/web/src/lib/create-island/factory.tsx
@@ -73,7 +73,11 @@ export function createIsland<P extends Record<string, unknown>>(
     exportName = Component.name,
     tagName = "x-island",
     rootTagName = "x-island-root",
-    serializeProps = (props) => JSON.stringify(props),
+    serializeProps = (props) =>
+      JSON.stringify(props)
+        .replace(/</g, "\\u003c")
+        .replace(/>/g, "\\u003e")
+        .replace(/&/g, "\\u0026"),
   } = options;
 
   if (!exportName) {

--- a/sources/web/src/lib/create-island/factory.tsx
+++ b/sources/web/src/lib/create-island/factory.tsx
@@ -28,7 +28,7 @@
 import type { NonceVariablesContext } from "#src/middleware/nonce";
 import { useRequestContext } from "hono/jsx-renderer";
 import { randomUUID } from "node:crypto";
-import type { ComponentType } from "preact";
+import type { ComponentChildren, ComponentType } from "preact";
 import { h } from "preact";
 import { renderToString } from "preact-render-to-string";
 
@@ -53,7 +53,9 @@ export interface CreateIslandOptions<P = Record<string, unknown>> {
   serializeProps?: (props: Partial<P>) => string;
 }
 
-export interface IslandProps {}
+export interface IslandProps {
+  children?: ComponentChildren;
+}
 
 /**
  * Creates a Preact Island wrapper component
@@ -90,26 +92,35 @@ export function createIsland<P extends Record<string, unknown>>(
     const {
       var: { nonce },
     } = useRequestContext<NonceVariablesContext>();
-    const componentProps = props;
+    const { children, ...rest } = props as P &
+      IslandProps & { children?: ComponentChildren };
     const root_id = randomUUID();
 
-    // Server-side rendering (only for hydrate mode)
-    const serverRenderedHTML =
-      mode === "hydrate"
-        ? renderToString(h(Component, componentProps as P))
-        : "";
+    // VNode children (objects) can't be JSON-serialized or passed cross-renderer
+    // to Preact's SSR; primitive children (strings/numbers) serialize normally.
+    const isVNodeChildren =
+      children !== null &&
+      children !== undefined &&
+      typeof children === "object";
 
-    // Inline script for client-side hydration/rendering
+    const serializableProps = isVNodeChildren
+      ? rest
+      : { ...rest, ...(children !== undefined ? { children } : {}) };
+
+    // Server-side rendering: only primitive children can pass through Preact's renderer
+    const ssrProps = isVNodeChildren ? (rest as P) : (serializableProps as P);
+    const serverRenderedHTML =
+      mode === "hydrate" ? renderToString(h(Component, ssrProps)) : "";
+
     const islandScript = generateIslandScript(
       mode,
       clientPath,
       exportName,
       root_id,
-      componentProps as Partial<P>,
+      serializableProps as Partial<P>,
       serializeProps,
     );
 
-    // Custom element tags - cast to any to allow dynamic tag names
     const IslandTag = tagName as any;
     const RootTag = rootTagName as any;
 
@@ -123,6 +134,7 @@ export function createIsland<P extends Record<string, unknown>>(
         ) : (
           <RootTag id={root_id} />
         )}
+        {isVNodeChildren && children}
         <script
           dangerouslySetInnerHTML={{ __html: islandScript }}
           defer

--- a/sources/web/src/routes/moderations/page.tsx
+++ b/sources/web/src/routes/moderations/page.tsx
@@ -227,65 +227,74 @@ async function Table() {
             <th>
               <SortHeaderIsland
                 name="status"
-                label="Statut"
                 aria-sort={aria_sort("status", search_sort)}
-              />
+              >
+                Statut
+              </SortHeaderIsland>
             </th>
             <th>
               <SortHeaderIsland
                 name="created"
-                label="Date de création"
                 aria-sort={aria_sort("created", search_sort)}
-              />
+              >
+                Date de création
+              </SortHeaderIsland>
             </th>
             <th>
               <SortHeaderIsland
                 name="updated"
-                label="Traité le"
                 aria-sort={aria_sort("updated", search_sort)}
-              />
+              >
+                Traité le
+              </SortHeaderIsland>
             </th>
             <th>
               <SortHeaderIsland
                 name="family-name"
-                label="Nom"
                 aria-sort={aria_sort("family-name", search_sort)}
-              />
+              >
+                Nom
+              </SortHeaderIsland>
             </th>
             <th>
               <SortHeaderIsland
                 name="given-name"
-                label="Prénom"
                 aria-sort={aria_sort("given-name", search_sort)}
-              />
+              >
+                Prénom
+              </SortHeaderIsland>
             </th>
             <th>
               <SortHeaderIsland
                 name="email"
-                label="Email"
                 aria-sort={aria_sort("email", search_sort)}
-              />
+              >
+                Email
+              </SortHeaderIsland>
             </th>
             <th>
               <SortHeaderIsland
                 name="organization"
-                label="Organisation cible"
                 aria-sort={aria_sort("organization", search_sort)}
-              />
+              >
+                Organisation cible
+              </SortHeaderIsland>
             </th>
             <th>
               <SortHeaderIsland
                 name="service"
-                label="Service"
                 aria-sort={aria_sort("service", search_sort)}
-              />
+              >
+                Service
+              </SortHeaderIsland>
             </th>
             <th>
               <SortHeaderIsland
                 name="id"
-                label="ID"
                 aria-sort={aria_sort("id", search_sort)}
-              />
+              >
+                ID
+              </SortHeaderIsland>
             </th>
           </tr>
         </thead>

--- a/sources/web/src/ui/moderations/Filter/sort-header.client.tsx
+++ b/sources/web/src/ui/moderations/Filter/sort-header.client.tsx
@@ -4,13 +4,13 @@ import { parsed, update_q } from "./q-signal.client";
 
 export interface SortHeaderProps extends Record<string, unknown> {
   name: string;
-  label: string;
+  children?: string;
   "aria-sort"?: "ascending" | "descending";
 }
 
 export function SortHeader({
   name,
-  label,
+  children,
   "aria-sort": initial_sort,
 }: SortHeaderProps) {
   const sort_asc = `${name}-asc`;
@@ -35,7 +35,7 @@ export function SortHeader({
       class="flex cursor-pointer items-center gap-1 font-semibold"
       onClick={handle_click}
     >
-      {label}
+      {children}
       {is_asc && <span aria-hidden="true">↑</span>}
       {is_desc && <span aria-hidden="true">↓</span>}
     </button>

--- a/sources/web/src/ui/organizations/info/About.test.tsx
+++ b/sources/web/src/ui/organizations/info/About.test.tsx
@@ -64,10 +64,10 @@ test("render about section", async () => {
               import { render, h } from "preact";
               import { CopyButtonClient } from "/src/ui/button/components/copy.client.js";
               const props = {
-                children: "",
                 className:
                   "disabled:bg-grey-200 disabled:text-grey-425 dark:disabled:bg-grey-850 dark:disabled:text-grey-625 inline-flex w-fit items-center font-medium no-underline disabled:cursor-not-allowed min-h-8 gap-1 text-sm leading-6 text-blue-france dark:text-blue-france-925 hover:bg-surface-hover dark:hover:bg-surface-hover bg-transparent shadow-[inset_0_0_0_1px_var(--color-border)] dark:bg-transparent aspect-square justify-center p-0 ml-2",
                 text: "cached_libelle",
+                children: "",
               };
               let mounted = false;
               const mount_island = () => {
@@ -100,10 +100,10 @@ test("render about section", async () => {
                 import { render, h } from "preact";
                 import { CopyButtonClient } from "/src/ui/button/components/copy.client.js";
                 const props = {
-                  children: "",
                   className:
                     "disabled:bg-grey-200 disabled:text-grey-425 dark:disabled:bg-grey-850 dark:disabled:text-grey-625 inline-flex w-fit items-center font-medium no-underline disabled:cursor-not-allowed min-h-8 gap-1 text-sm leading-6 text-blue-france dark:text-blue-france-925 hover:bg-surface-hover dark:hover:bg-surface-hover bg-transparent shadow-[inset_0_0_0_1px_var(--color-border)] dark:bg-transparent aspect-square justify-center p-0",
                   text: "siret",
+                  children: "",
                 };
                 let mounted = false;
                 const mount_island = () => {


### PR DESCRIPTION
**Problem**

Islands had no way to accept children — either as VNode content rendered server-side alongside the island, or as primitive values (strings) passed through to the Preact component.

Additionally, the SSR call passed Hono's raw props object to Preact's renderToString, which silently dropped children due to cross-renderer incompatibility.

**Proposal**

- Add `children?: ComponentChildren` to `IslandProps`
- Detect VNode children (objects): exclude from client serialization, render via Hono JSX inside the island wrapper instead
- Detect primitive children (strings/numbers): serialize normally and pass through to Preact SSR via a plain spread object
- Use `serializableProps` (not raw Hono props) for SSR to avoid the cross-renderer children drop
- Apply to `SortHeaderIsland` as first real usage: replace `label` prop with children for more idiomatic call sites