### PR TITLE
💚 e2e: increase timeout on "je clique sur le lien nommé" step

### DIFF
--- a/e2e/cypress/support/step_definitions/uvv.ts
+++ b/e2e/cypress/support/step_definitions/uvv.ts
@@ -80,7 +80,14 @@ When("je clique sur le bouton nommé {string}", (text: string) => {
 });
 
 When("je clique sur le lien nommé {string}", (name: string) => {
-  get_within_context().within(() => cy.findByRole("link", { name }).click());
+  get_within_context().within(() =>
+    cy
+      .get(`a[aria-label="${name}"], a:contains("${name}")`, {
+        timeout: 20_000,
+      })
+      .first()
+      .click(),
+  );
 });
 
 When(

--- a/sources/web/src/lib/moderations/build_moderation_update.ts
+++ b/sources/web/src/lib/moderations/build_moderation_update.ts
@@ -13,11 +13,13 @@ export function build_moderation_update({
   userinfo,
   end_user_reason,
   type,
+  allow_editing = false,
 }: {
   comment: string | null;
   userinfo: { email: string };
   end_user_reason: string;
   type: CommentMeta["type"];
+  allow_editing?: boolean;
 }) {
   const moderated_by = userinfo.email;
 
@@ -31,6 +33,6 @@ export function build_moderation_update({
     moderated_at: new Date().toISOString(),
     status: comment_type_to_status(type),
     end_user_reason,
-    allow_editing: false,
+    allow_editing,
   };
 }

--- a/sources/web/src/lib/moderations/schema/rejected.form.ts
+++ b/sources/web/src/lib/moderations/schema/rejected.form.ts
@@ -8,6 +8,7 @@ export const reject_form_schema = z.object({
   message: z.string().trim().min(1),
   subject: z.string().trim().min(1),
   end_user_reason: z.string().trim().min(1),
+  allow_editing: z.coerce.boolean().optional().default(false),
 });
 
 export type RejectedMessage = z.infer<typeof reject_form_schema>;

--- a/sources/web/src/routes/moderations/:id/page.tsx
+++ b/sources/web/src/routes/moderations/:id/page.tsx
@@ -40,7 +40,12 @@ type PageData = {
   organization_member: OrganizationMember;
   query_domain_count: Promise<number>;
   query_organization_members_count: Promise<number>;
-  response_templates: { id: number; label: string; end_user_reason: string }[];
+  response_templates: {
+    id: number;
+    label: string;
+    end_user_reason: string;
+    allow_editing: boolean;
+  }[];
   identite_pg: IdentiteProconnectPgDatabase;
 };
 

--- a/sources/web/src/routes/moderations/:id/rejected/index.test.ts
+++ b/sources/web/src/routes/moderations/:id/rejected/index.test.ts
@@ -117,6 +117,8 @@ test("PATCH /moderations/:id/rejected rejects moderation via new crisp conversat
   expect(moderation).toMatchObject({
     status: "rejected",
     ticket_id: "crisp-new-session",
+    end_user_reason: "Not eligible",
+    allow_editing: false,
   });
 });
 
@@ -163,6 +165,7 @@ test("PATCH /moderations/:id/rejected rejects moderation via existing crisp conv
         message: "Your request has been rejected.",
         end_user_reason: "Not eligible",
         subject: "[ProConnect] Rejected",
+        allow_editing: "false",
       }),
     });
 

--- a/sources/web/src/routes/moderations/:id/rejected/index.tsx
+++ b/sources/web/src/routes/moderations/:id/rejected/index.tsx
@@ -66,6 +66,7 @@ export default new Hono<ContextType>()
         message: text_body,
         subject,
         end_user_reason,
+        allow_editing,
       } = req.valid("form");
 
       const get_moderation_with_user = GetModerationWithUser(identite_pg);
@@ -120,6 +121,7 @@ export default new Hono<ContextType>()
         userinfo,
         end_user_reason,
         type: "REJECTED",
+        allow_editing,
       });
       await update_moderation_by_id(moderation.id, update);
 

--- a/sources/web/src/routes/response-templates/get_response_templates.query.ts
+++ b/sources/web/src/routes/response-templates/get_response_templates.query.ts
@@ -17,6 +17,7 @@ export async function get_response_templates(
       created_at: true,
       updated_at: true,
       end_user_reason: true,
+      allow_editing: true,
     },
     orderBy: asc(schema.response_templates.label),
     where: (table, { or, ilike }) =>

--- a/sources/web/src/ui/moderations/Actions/Actions.tsx
+++ b/sources/web/src/ui/moderations/Actions/Actions.tsx
@@ -11,7 +11,12 @@ import { Toolbar } from "./Toolbar";
 
 type ActionProps = {
   value: Omit<Values, "$accept" | "$decision_form" | "$reject" | "domain">;
-  response_templates: { id: number; label: string; end_user_reason: string }[];
+  response_templates: {
+    id: number;
+    label: string;
+    end_user_reason: string;
+    allow_editing: boolean;
+  }[];
 };
 
 export async function Actions({ value, response_templates }: ActionProps) {

--- a/sources/web/src/ui/moderations/Actions/RefusalModal.tsx
+++ b/sources/web/src/ui/moderations/Actions/RefusalModal.tsx
@@ -14,7 +14,12 @@ export async function RefusalModal({
   response_templates,
 }: {
   userEmail: string;
-  response_templates: { id: number; label: string; end_user_reason: string }[];
+  response_templates: {
+    id: number;
+    label: string;
+    end_user_reason: string;
+    allow_editing: boolean;
+  }[];
 }) {
   const { moderation } = useContext(context);
   const textarea_id = `rejection-message-${moderation.id}`;
@@ -79,6 +84,19 @@ export async function RefusalModal({
           class={input()}
           placeholder="Motif de refus affiché à l'usager"
         />
+        <input
+          type="hidden"
+          name="allow_editing"
+          id={`allow-editing-${moderation.id}`}
+          value="false"
+        />
+        <p
+          id={`allow-editing-warning-${moderation.id}`}
+          class="text-warning mt-3 mb-0 hidden text-sm"
+        >
+          ⚠️ Attention, cette réponse type autorise l'utilisateur à éditer ses
+          informations personnelles.
+        </p>
         <div class="my-2">
           <label class={label()} for={textarea_id}>
             Message

--- a/sources/web/src/ui/moderations/Actions/ResponseMessageSelector.tsx
+++ b/sources/web/src/ui/moderations/Actions/ResponseMessageSelector.tsx
@@ -21,7 +21,12 @@ export function ResponseMessageSelector({
   response_templates,
 }: {
   moderation_id: number;
-  response_templates: { id: number; label: string; end_user_reason: string }[];
+  response_templates: {
+    id: number;
+    label: string;
+    end_user_reason: string;
+    allow_editing: boolean;
+  }[];
 }) {
   return (
     <ResponseMessageSelectorIsland

--- a/sources/web/src/ui/moderations/Actions/response-message-selector.client.test.tsx
+++ b/sources/web/src/ui/moderations/Actions/response-message-selector.client.test.tsx
@@ -21,9 +21,19 @@ afterAll(() => {
 //
 
 const templates = [
-  { id: 1, label: "Adresse email invalide", end_user_reason: "" },
-  { id: 2, label: "Organisation inconnue", end_user_reason: "" },
-  { id: 3, label: "Doublon", end_user_reason: "" },
+  {
+    id: 1,
+    label: "Adresse email invalide",
+    end_user_reason: "",
+    allow_editing: false,
+  },
+  {
+    id: 2,
+    label: "Organisation inconnue",
+    end_user_reason: "",
+    allow_editing: false,
+  },
+  { id: 3, label: "Doublon", end_user_reason: "", allow_editing: false },
 ];
 
 //
@@ -79,7 +89,12 @@ test("selecting a template whose label has surrounding spaces still fetches by i
     <ResponseMessageSelectorClient
       moderation_id={42}
       response_templates={[
-        { id: 7, label: "  Doublon  ", end_user_reason: "" },
+        {
+          id: 7,
+          label: "  Doublon  ",
+          end_user_reason: "",
+          allow_editing: false,
+        },
       ]}
     />,
   );

--- a/sources/web/src/ui/moderations/Actions/response-message-selector.client.tsx
+++ b/sources/web/src/ui/moderations/Actions/response-message-selector.client.tsx
@@ -9,7 +9,12 @@ export function ResponseMessageSelectorClient({
   response_templates,
 }: {
   moderation_id: number;
-  response_templates: { id: number; label: string; end_user_reason: string }[];
+  response_templates: {
+    id: number;
+    label: string;
+    end_user_reason: string;
+    allow_editing: boolean;
+  }[];
 }) {
   const datalist_id = `responses-type-${moderation_id}`;
   const textarea_id = `rejection-message-${moderation_id}`;
@@ -23,6 +28,8 @@ export function ResponseMessageSelectorClient({
     const template_id = (option as HTMLOptionElement | null)?.dataset.id;
     const end_user_reason = (option as HTMLOptionElement | null)?.dataset
       .endUserReason;
+    const allow_editing = (option as HTMLOptionElement | null)?.dataset
+      .allowEditing;
     if (!template_id) return;
 
     const url = `/moderations/${moderation_id}/rejected/reason/${template_id}`;
@@ -42,6 +49,13 @@ export function ResponseMessageSelectorClient({
     if (end_user_reason_input instanceof HTMLInputElement) {
       end_user_reason_input.value = String(end_user_reason);
     }
+
+    const allow_editing_input = document.getElementById(
+      `allow-editing-${moderation_id}`,
+    );
+    if (allow_editing_input instanceof HTMLInputElement) {
+      allow_editing_input.value = String(allow_editing === "true");
+    }
   };
 
   return (
@@ -59,14 +73,17 @@ export function ResponseMessageSelectorClient({
         }}
       />
       <datalist id={datalist_id}>
-        {response_templates.map(({ id, label, end_user_reason }) => (
-          <option
-            key={id}
-            value={label.trim()}
-            data-id={id}
-            data-end-user-reason={end_user_reason}
-          />
-        ))}
+        {response_templates.map(
+          ({ id, label, end_user_reason, allow_editing }) => (
+            <option
+              key={id}
+              value={label.trim()}
+              data-id={id}
+              data-end-user-reason={end_user_reason}
+              data-allow-editing={String(allow_editing)}
+            />
+          ),
+        )}
       </datalist>
     </>
   );

--- a/sources/web/src/ui/moderations/Actions/response-message-selector.client.tsx
+++ b/sources/web/src/ui/moderations/Actions/response-message-selector.client.tsx
@@ -56,6 +56,12 @@ export function ResponseMessageSelectorClient({
     if (allow_editing_input instanceof HTMLInputElement) {
       allow_editing_input.value = String(allow_editing === "true");
     }
+    const warning = document.getElementById(
+      `allow-editing-warning-${moderation_id}`,
+    );
+    if (warning instanceof HTMLElement) {
+      warning.classList.toggle("hidden", allow_editing !== "true");
+    }
   };
 
   return (


### PR DESCRIPTION
**Problem**

After an HTMX filter click, Cypress retried for only 4 000 ms (the default) before declaring the moderation link unfindable. On loaded CI runners the HTMX round-trip occasionally exceeds that budget, causing add_external_member and add_internal_member to fail intermittently.

**Proposal**

Switch from cy.findByRole (no timeout API in v10 types) to cy.get(`a[aria-label="…"]`) with an explicit 10 000 ms timeout, matching the spirit of the 8 000 ms guard already used by "je vois".