### PR TITLE
✨ users: surface OIDC connection history on user page

### DIFF
--- a/.release-it-changeset/1781107510-users-historique-connexion-oidc.md
+++ b/.release-it-changeset/1781107510-users-historique-connexion-oidc.md
@@ -1,0 +1,3 @@
+✨ Historique de connexion aux services sur la fiche utilisateur
+
+La fiche utilisateur affiche désormais un tableau de l'historique de connexion aux services ProConnect, chargé de manière asynchrone. Chaque entrée indique la date, le service (nom du client OIDC) et l'organisation utilisée lors de la connexion.

--- a/sources/identite-proconnect/src/database/seed/insert.ts
+++ b/sources/identite-proconnect/src/database/seed/insert.ts
@@ -7,6 +7,9 @@ import { schema } from "..";
 import { insert_nordPass_authenticator } from "./authenticators/nordPass";
 import { insert_1Password_authenticator } from "./authenticators/onePassword";
 import { insert_email_deliverability_whitelist } from "./email_deliverability_whitelist";
+import { insert_annuaire_entreprises } from "./oidc_clients/annuaire_entreprises";
+import { insert_resana } from "./oidc_clients/resana";
+import { insert_tchap } from "./oidc_clients/tchap";
 import { insert_abracadabra } from "./organizations/abracadabra";
 import { insert_aldp } from "./organizations/aldp";
 import { insert_bosch_france } from "./organizations/bosch_france";
@@ -24,6 +27,8 @@ import { insert_pierrebon } from "./users/pierrebon";
 import { insert_raphael } from "./users/raphael";
 import { insert_raphael_alpha } from "./users/raphael_alpha";
 import { insert_richardbon } from "./users/richardbon";
+import { insert_jean_bon_oidc_connections } from "./users_oidc_clients/jean_bon";
+import { insert_raphael_oidc_connections } from "./users_oidc_clients/raphael";
 
 //
 
@@ -287,6 +292,36 @@ export async function insert_database(db: IdentiteProconnectPgDatabase) {
     );
     await insert_nordPass_authenticator(db, raphael_alpha.id);
     consola.verbose(`🌱 INSERT ${raphael_alpha.given_name} NordPass setup...`);
+
+    //
+
+    const annuaire_entreprises = await insert_annuaire_entreprises(db);
+    consola.verbose(
+      `🌱 INSERT oidc_client ${annuaire_entreprises.client_name}`,
+    );
+    const tchap = await insert_tchap(db);
+    consola.verbose(`🌱 INSERT oidc_client ${tchap.client_name}`);
+    const resana = await insert_resana(db);
+    consola.verbose(`🌱 INSERT oidc_client ${resana.client_name}`);
+
+    await insert_raphael_oidc_connections(db, {
+      oidc_client_id: annuaire_entreprises.id,
+      organization_id: dinum.id,
+      user_id: raphael.id,
+    });
+    consola.verbose(
+      `🌱 INSERT ${raphael.given_name} connection history (${annuaire_entreprises.client_name})`,
+    );
+
+    await insert_jean_bon_oidc_connections(db, {
+      dinum_id: dinum.id,
+      resana_id: resana.id,
+      tchap_id: tchap.id,
+      user_id: jean_bon.id,
+    });
+    consola.verbose(
+      `🌱 INSERT ${jean_bon.given_name} connection history (${tchap.client_name}, ${resana.client_name})`,
+    );
 
     await insert_franceconnect_userinfo(db, {
       birthcountry: "99100",

--- a/sources/identite-proconnect/src/database/seed/oidc_clients/annuaire_entreprises.ts
+++ b/sources/identite-proconnect/src/database/seed/oidc_clients/annuaire_entreprises.ts
@@ -1,0 +1,17 @@
+import type { IdentiteProconnectPgDatabase } from "../..";
+import { schema } from "../..";
+
+export async function insert_annuaire_entreprises(
+  db: IdentiteProconnectPgDatabase,
+) {
+  const insert = await db
+    .insert(schema.oidc_clients)
+    .values({
+      client_id: "annuaire-entreprises",
+      client_name: "Annuaire des entreprises",
+      client_secret: "seed-secret-annuaire-entreprises",
+    })
+    .returning();
+
+  return insert.at(0)!;
+}

--- a/sources/identite-proconnect/src/database/seed/oidc_clients/resana.ts
+++ b/sources/identite-proconnect/src/database/seed/oidc_clients/resana.ts
@@ -1,0 +1,15 @@
+import type { IdentiteProconnectPgDatabase } from "../..";
+import { schema } from "../..";
+
+export async function insert_resana(db: IdentiteProconnectPgDatabase) {
+  const insert = await db
+    .insert(schema.oidc_clients)
+    .values({
+      client_id: "resana",
+      client_name: "Resana",
+      client_secret: "seed-secret-resana",
+    })
+    .returning();
+
+  return insert.at(0)!;
+}

--- a/sources/identite-proconnect/src/database/seed/oidc_clients/tchap.ts
+++ b/sources/identite-proconnect/src/database/seed/oidc_clients/tchap.ts
@@ -1,0 +1,15 @@
+import type { IdentiteProconnectPgDatabase } from "../..";
+import { schema } from "../..";
+
+export async function insert_tchap(db: IdentiteProconnectPgDatabase) {
+  const insert = await db
+    .insert(schema.oidc_clients)
+    .values({
+      client_id: "tchap",
+      client_name: "Tchap",
+      client_secret: "seed-secret-tchap",
+    })
+    .returning();
+
+  return insert.at(0)!;
+}

--- a/sources/identite-proconnect/src/database/seed/unicorn.ts
+++ b/sources/identite-proconnect/src/database/seed/unicorn.ts
@@ -91,6 +91,49 @@ export async function create_pink_diamond_user(
   return user_id;
 }
 
+export async function create_unicorn_oidc_client(
+  pg: IdentiteProconnectPgDatabase,
+) {
+  const [{ id: oidc_client_id } = { id: NaN }] = await pg
+    .insert(schema.oidc_clients)
+    .values({
+      client_id: "🦄 client_id",
+      client_name: "🦄 client_name",
+      client_secret: "🦄 client_secret",
+    })
+    .returning({ id: schema.oidc_clients.id });
+
+  return oidc_client_id;
+}
+
+export async function create_adora_pony_oidc_connection(
+  pg: IdentiteProconnectPgDatabase,
+  override: Partial<
+    Omit<typeof schema.users_oidc_clients.$inferInsert, "user_id">
+  > = {},
+) {
+  const adora_pony_user = await pg.query.users.findFirst({
+    columns: { id: true },
+    where: eq(schema.users.email, "adora.pony@unicorn.xyz"),
+  });
+  const unicorn_oidc_client = await pg.query.oidc_clients.findFirst({
+    columns: { id: true },
+    where: eq(schema.oidc_clients.client_id, "🦄 client_id"),
+  });
+  const [{ id: connection_id } = { id: NaN }] = await pg
+    .insert(schema.users_oidc_clients)
+    .values({
+      created_at: new Date().toISOString(),
+      oidc_client_id: unicorn_oidc_client!.id,
+      updated_at: new Date().toISOString(),
+      user_id: adora_pony_user!.id,
+      ...override,
+    })
+    .returning({ id: schema.users_oidc_clients.id });
+
+  return connection_id;
+}
+
 export async function create_red_diamond_user(
   pg: IdentiteProconnectPgDatabase,
 ) {

--- a/sources/identite-proconnect/src/database/seed/users_oidc_clients/jean_bon.ts
+++ b/sources/identite-proconnect/src/database/seed/users_oidc_clients/jean_bon.ts
@@ -1,0 +1,37 @@
+import type { IdentiteProconnectPgDatabase } from "../..";
+import { schema } from "../..";
+
+export async function insert_jean_bon_oidc_connections(
+  db: IdentiteProconnectPgDatabase,
+  {
+    tchap_id,
+    resana_id,
+    dinum_id,
+    user_id,
+  }: {
+    tchap_id: number;
+    resana_id: number;
+    dinum_id: number;
+    user_id: number;
+  },
+) {
+  return db.insert(schema.users_oidc_clients).values([
+    {
+      created_at: "2022-03-10T08:45:00+01:00",
+      oidc_client_id: tchap_id,
+      organization_id: dinum_id,
+      sp_name: "Tchap",
+      updated_at: "2022-03-10T08:45:00+01:00",
+      user_ip_address: "172.16.0.5",
+      user_id,
+    },
+    {
+      created_at: "2023-11-20T16:00:00+01:00",
+      oidc_client_id: resana_id,
+      organization_id: dinum_id,
+      sp_name: "Resana",
+      updated_at: "2023-11-20T16:00:00+01:00",
+      user_id,
+    },
+  ]);
+}

--- a/sources/identite-proconnect/src/database/seed/users_oidc_clients/raphael.ts
+++ b/sources/identite-proconnect/src/database/seed/users_oidc_clients/raphael.ts
@@ -1,0 +1,44 @@
+import type { IdentiteProconnectPgDatabase } from "../..";
+import { schema } from "../..";
+
+export async function insert_raphael_oidc_connections(
+  db: IdentiteProconnectPgDatabase,
+  {
+    oidc_client_id,
+    organization_id,
+    user_id,
+  }: {
+    oidc_client_id: number;
+    organization_id: number;
+    user_id: number;
+  },
+) {
+  return db.insert(schema.users_oidc_clients).values([
+    {
+      created_at: "2023-06-01T09:12:00+02:00",
+      oidc_client_id,
+      organization_id,
+      sp_name: "Annuaire des entreprises",
+      updated_at: "2023-06-01T09:12:00+02:00",
+      user_id,
+    },
+    {
+      created_at: "2023-08-15T14:30:00+02:00",
+      oidc_client_id,
+      organization_id,
+      sp_name: "Annuaire des entreprises",
+      updated_at: "2023-08-15T14:30:00+02:00",
+      user_ip_address: "192.168.1.42",
+      user_id,
+    },
+    {
+      created_at: "2024-01-10T10:05:00+01:00",
+      oidc_client_id,
+      organization_id: null,
+      sp_name: "Annuaire des entreprises",
+      updated_at: "2024-01-10T10:05:00+01:00",
+      user_ip_address: "10.0.0.7",
+      user_id,
+    },
+  ]);
+}

--- a/sources/identite-proconnect/src/database/testing/index.ts
+++ b/sources/identite-proconnect/src/database/testing/index.ts
@@ -17,9 +17,15 @@ export const pg = drizzle(client, { schema });
 export async function empty_database() {
   await pg.transaction(async (tx) => {
     await tx.delete(schema.users_organizations);
+    await tx.delete(schema.users_oidc_clients);
+    await tx.execute(
+      sql`ALTER SEQUENCE users_oidc_clients_id_seq RESTART WITH 1`,
+    );
     //
     await tx.delete(schema.email_domains);
     await tx.execute(sql`ALTER SEQUENCE email_domains_id_seq RESTART WITH 1`);
+    await tx.delete(schema.oidc_clients);
+    await tx.execute(sql`ALTER SEQUENCE oidc_clients_id_seq RESTART WITH 1`);
     await tx.delete(schema.organizations);
     await tx.execute(sql`ALTER SEQUENCE organizations_id_seq RESTART WITH 1`);
     await tx.delete(schema.moderations);

--- a/sources/web/src/routes.d.ts
+++ b/sources/web/src/routes.d.ts
@@ -226,19 +226,38 @@ declare const app: import("hono/hono-base").HonoBase<
             };
           } & {
             "/authorize": {
-              $get: {
-                input: {
-                  query: {
-                    client_id: string;
-                    nonce: string;
-                    redirect_uri: string;
-                    state: string;
+              $get:
+                | {
+                    input: {
+                      query: {
+                        client_id: string;
+                        nonce: string;
+                        redirect_uri: string;
+                        state: string;
+                      };
+                    };
+                    output: undefined;
+                    outputFormat: "redirect";
+                    status: 302;
+                  }
+                | {
+                    input: {
+                      query: {
+                        client_id: string;
+                        nonce: string;
+                        redirect_uri: string;
+                        state: string;
+                      };
+                    };
+                    output: import("zod").ZodSafeParseError<{
+                      client_id: string;
+                      nonce: string;
+                      redirect_uri: string;
+                      state: string;
+                    }>;
+                    outputFormat: "json";
+                    status: 400;
                   };
-                };
-                output: undefined;
-                outputFormat: "redirect";
-                status: 302;
-              };
             };
           } & {
             "/interaction/:code/login": {
@@ -291,17 +310,32 @@ declare const app: import("hono/hono-base").HonoBase<
             };
           } & {
             "/session/end": {
-              $get: {
-                input: {
-                  query: {
-                    post_logout_redirect_uri: string;
-                    state?: string | undefined;
+              $get:
+                | {
+                    input: {
+                      query: {
+                        post_logout_redirect_uri: string;
+                        state: string;
+                      };
+                    };
+                    output: {};
+                    outputFormat: string;
+                    status: import("hono/utils/http-status").StatusCode;
+                  }
+                | {
+                    input: {
+                      query: {
+                        post_logout_redirect_uri: string;
+                        state: string;
+                      };
+                    };
+                    output: import("zod").ZodSafeParseError<{
+                      post_logout_redirect_uri: string;
+                      state: string;
+                    }>;
+                    outputFormat: "json";
+                    status: 400;
                   };
-                };
-                output: {};
-                outputFormat: string;
-                status: import("hono/utils/http-status").StatusCode;
-              };
             };
           },
           "/auth.agentconnect.gouv.fr/api/v2"
@@ -341,9 +375,20 @@ declare const app: import("hono/hono-base").HonoBase<
                   data: {
                     session_id: string;
                     messages: {
+                      session_id: string;
+                      website_id: string;
                       content: string;
                       type: string;
+                      from: string;
+                      origin: string;
+                      user: {
+                        [x: string]: import("hono/utils/types").JSONValue;
+                      };
+                      fingerprint: number;
                       timestamp: number;
+                      edited: boolean;
+                      read: string;
+                      delivered: string;
                     }[];
                   }[];
                 };
@@ -363,8 +408,18 @@ declare const app: import("hono/hono-base").HonoBase<
                 };
                 output: {
                   data: {
+                    created_at: number;
+                    last_message: string;
                     meta: {
-                      subjet: string;
+                      avatar: string;
+                      data: {};
+                      device: {};
+                      email: string;
+                      ip: string;
+                      nickname: string;
+                      phone: string;
+                      segments: never[];
+                      subject: string;
                     };
                   };
                 };
@@ -401,7 +456,7 @@ declare const app: import("hono/hono-base").HonoBase<
                 };
                 output: {
                   data: {
-                    fingerprint: string;
+                    fingerprint: number;
                   };
                 };
                 outputFormat: "json";
@@ -420,9 +475,20 @@ declare const app: import("hono/hono-base").HonoBase<
                 };
                 output: {
                   data: {
+                    session_id: string;
+                    website_id: string;
                     content: string;
                     type: string;
+                    from: string;
+                    origin: string;
+                    user: {
+                      [x: string]: import("hono/utils/types").JSONValue;
+                    };
+                    fingerprint: number;
                     timestamp: number;
+                    edited: boolean;
+                    read: string;
+                    delivered: string;
                   }[];
                 };
                 outputFormat: "json";
@@ -483,6 +549,45 @@ declare const app: import("hono/hono-base").HonoBase<
             };
           },
           "/api.crisp.chat"
+        >
+      | import("hono/types").MergeSchemaPath<
+          {
+            "/readyz": {
+              $get: {
+                input: {};
+                output: "readyz check passed";
+                outputFormat: "text";
+                status: import("hono/utils/http-status").ContentfulStatusCode;
+              };
+            };
+          } & {
+            "/v4/djepva/api-association/associations/:siren_or_rna": {
+              $get: {
+                input: {
+                  param: {
+                    siren_or_rna: string;
+                  };
+                };
+                output: {};
+                outputFormat: "json";
+                status: import("hono/utils/http-status").ContentfulStatusCode;
+              };
+            };
+          } & {
+            "/proxy/files/:id": {
+              $get: {
+                input: {
+                  param: {
+                    id: string;
+                  };
+                };
+                output: `${string} - Requested GET on /proxy/files/${string}`;
+                outputFormat: "text";
+                status: import("hono/utils/http-status").ContentfulStatusCode;
+              };
+            };
+          },
+          "/entreprise.api.gouv.fr"
         >,
       "/___dev___"
     >
@@ -498,18 +603,35 @@ declare const app: import("hono/hono-base").HonoBase<
         };
       } & {
         "/login/callback": {
-          $get: {
-            input: {
-              query: {
-                code: string;
-                iss: string;
-                state: string;
+          $get:
+            | {
+                input: {
+                  query: {
+                    code: string;
+                    iss: string;
+                    state: string;
+                  };
+                };
+                output: undefined;
+                outputFormat: "redirect";
+                status: 302;
+              }
+            | {
+                input: {
+                  query: {
+                    code: string;
+                    iss: string;
+                    state: string;
+                  };
+                };
+                output: import("zod").ZodSafeParseError<{
+                  code: string;
+                  iss: string;
+                  state: string;
+                }>;
+                outputFormat: "json";
+                status: 400;
               };
-            };
-            output: undefined;
-            outputFormat: "redirect";
-            status: 302;
-          };
         };
       } & {
         "/logout": {
@@ -522,16 +644,29 @@ declare const app: import("hono/hono-base").HonoBase<
         };
       } & {
         "/logout/callback": {
-          $get: {
-            input: {
-              query: {
-                state: string;
+          $get:
+            | {
+                input: {
+                  query: {
+                    state: string;
+                  };
+                };
+                output: undefined;
+                outputFormat: "redirect";
+                status: 302;
+              }
+            | {
+                input: {
+                  query: {
+                    state: string;
+                  };
+                };
+                output: import("zod").ZodSafeParseError<{
+                  state: string;
+                }>;
+                outputFormat: "json";
+                status: 400;
               };
-            };
-            output: undefined;
-            outputFormat: "redirect";
-            status: 302;
-          };
         };
       },
       "/auth"
@@ -542,35 +677,81 @@ declare const app: import("hono/hono-base").HonoBase<
         | import("hono/types").MergeSchemaPath<
             | {
                 "/": {
-                  $get: {
-                    input: {
-                      param: {
-                        id: string;
+                  $get:
+                    | {
+                        input: {
+                          param: {
+                            id: string;
+                          };
+                        };
+                        output: import("zod").ZodSafeParseError<{
+                          id: number;
+                        }>;
+                        outputFormat: "json";
+                        status: 400;
+                      }
+                    | {
+                        input: {
+                          param: {
+                            id: string;
+                          };
+                        };
+                        output: {};
+                        outputFormat: string;
+                        status: import("hono/utils/http-status").StatusCode;
                       };
-                    };
-                    output: {};
-                    outputFormat: string;
-                    status: import("hono/utils/http-status").StatusCode;
-                  };
                 };
               }
             | import("hono/types").MergeSchemaPath<
                 {
                   "/": {
-                    $get: {
-                      input: {
-                        param: {
-                          id: string;
+                    $get:
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                            };
+                          } & {
+                            query: {
+                              describedby: string;
+                            };
+                          };
+                          output: {};
+                          outputFormat: string;
+                          status: import("hono/utils/http-status").StatusCode;
+                        }
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                            };
+                          } & {
+                            query: {
+                              describedby: string;
+                            };
+                          };
+                          output: import("zod").ZodSafeParseError<{
+                            id: number;
+                          }>;
+                          outputFormat: "json";
+                          status: 400;
+                        }
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                            };
+                          } & {
+                            query: {
+                              describedby: string;
+                            };
+                          };
+                          output: import("zod").ZodSafeParseError<{
+                            describedby: string;
+                          }>;
+                          outputFormat: "json";
+                          status: 400;
                         };
-                      } & {
-                        query: {
-                          describedby: string;
-                        };
-                      };
-                      output: {};
-                      outputFormat: string;
-                      status: import("hono/utils/http-status").StatusCode;
-                    };
                   };
                 },
                 "/email"
@@ -578,21 +759,57 @@ declare const app: import("hono/hono-base").HonoBase<
             | import("hono/types").MergeSchemaPath<
                 {
                   "/": {
-                    $get: {
-                      input: {
-                        param: {
-                          id: string;
+                    $get:
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                            };
+                          } & {
+                            query: {
+                              organization_id: string | string[];
+                              user_id: string | string[];
+                            };
+                          };
+                          output: {};
+                          outputFormat: string;
+                          status: import("hono/utils/http-status").StatusCode;
+                        }
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                            };
+                          } & {
+                            query: {
+                              organization_id: string | string[];
+                              user_id: string | string[];
+                            };
+                          };
+                          output: import("zod").ZodSafeParseError<{
+                            id: number;
+                          }>;
+                          outputFormat: "json";
+                          status: 400;
+                        }
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                            };
+                          } & {
+                            query: {
+                              organization_id: string | string[];
+                              user_id: string | string[];
+                            };
+                          };
+                          output: import("zod").ZodSafeParseError<{
+                            organization_id: number;
+                            user_id: number;
+                          }>;
+                          outputFormat: "json";
+                          status: 400;
                         };
-                      } & {
-                        query: {
-                          organization_id: string | string[];
-                          user_id: string | string[];
-                        };
-                      };
-                      output: {};
-                      outputFormat: string;
-                      status: import("hono/utils/http-status").StatusCode;
-                    };
                   };
                 },
                 "/duplicate_warning"
@@ -600,40 +817,137 @@ declare const app: import("hono/hono-base").HonoBase<
             | import("hono/types").MergeSchemaPath<
                 {
                   "/": {
-                    $patch: {
-                      input: {
-                        param: {
-                          id: string;
+                    $patch:
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                            };
+                          } & {
+                            form: {
+                              add_member: "AS_INTERNAL" | "AS_EXTERNAL";
+                              add_domain?: string | undefined;
+                              send_notification?: string | undefined;
+                              verification_type?:
+                                | "domain"
+                                | "organization_dirigeant"
+                                | "code_sent_to_official_contact_email"
+                                | "imported_from_coop_mediation_numerique"
+                                | "imported_from_inclusion_connect"
+                                | "in_liste_dirigeants_rna"
+                                | "in_liste_dirigeants_rne"
+                                | "official_contact_email"
+                                | "ordre_professionnel_domain"
+                                | "proof_received"
+                                | "verified_by_coop_mediation_numerique"
+                                | "bypassed"
+                                | "domain_not_verified_yet"
+                                | "no_validation_means_available"
+                                | "no_verification_means_for_entreprise_unipersonnelle"
+                                | "no_verification_means_for_small_association"
+                                | "no_verification_means_for_small_organization"
+                                | undefined;
+                            };
+                          };
+                          output: {};
+                          outputFormat: string;
+                          status: import("hono/utils/http-status").StatusCode;
+                        }
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                            };
+                          } & {
+                            form: {
+                              add_member: "AS_INTERNAL" | "AS_EXTERNAL";
+                              add_domain?: string | undefined;
+                              send_notification?: string | undefined;
+                              verification_type?:
+                                | "domain"
+                                | "organization_dirigeant"
+                                | "code_sent_to_official_contact_email"
+                                | "imported_from_coop_mediation_numerique"
+                                | "imported_from_inclusion_connect"
+                                | "in_liste_dirigeants_rna"
+                                | "in_liste_dirigeants_rne"
+                                | "official_contact_email"
+                                | "ordre_professionnel_domain"
+                                | "proof_received"
+                                | "verified_by_coop_mediation_numerique"
+                                | "bypassed"
+                                | "domain_not_verified_yet"
+                                | "no_validation_means_available"
+                                | "no_verification_means_for_entreprise_unipersonnelle"
+                                | "no_verification_means_for_small_association"
+                                | "no_verification_means_for_small_organization"
+                                | undefined;
+                            };
+                          };
+                          output: import("zod").ZodSafeParseError<{
+                            id: number;
+                          }>;
+                          outputFormat: "json";
+                          status: 400;
+                        }
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                            };
+                          } & {
+                            form: {
+                              add_member: "AS_INTERNAL" | "AS_EXTERNAL";
+                              add_domain?: string | undefined;
+                              send_notification?: string | undefined;
+                              verification_type?:
+                                | "domain"
+                                | "organization_dirigeant"
+                                | "code_sent_to_official_contact_email"
+                                | "imported_from_coop_mediation_numerique"
+                                | "imported_from_inclusion_connect"
+                                | "in_liste_dirigeants_rna"
+                                | "in_liste_dirigeants_rne"
+                                | "official_contact_email"
+                                | "ordre_professionnel_domain"
+                                | "proof_received"
+                                | "verified_by_coop_mediation_numerique"
+                                | "bypassed"
+                                | "domain_not_verified_yet"
+                                | "no_validation_means_available"
+                                | "no_verification_means_for_entreprise_unipersonnelle"
+                                | "no_verification_means_for_small_association"
+                                | "no_verification_means_for_small_organization"
+                                | undefined;
+                            };
+                          };
+                          output: import("zod").ZodSafeParseError<{
+                            add_domain: boolean;
+                            add_member: "AS_INTERNAL" | "AS_EXTERNAL";
+                            send_notification: boolean;
+                            verification_type?:
+                              | "domain"
+                              | "organization_dirigeant"
+                              | "code_sent_to_official_contact_email"
+                              | "imported_from_coop_mediation_numerique"
+                              | "imported_from_inclusion_connect"
+                              | "in_liste_dirigeants_rna"
+                              | "in_liste_dirigeants_rne"
+                              | "official_contact_email"
+                              | "ordre_professionnel_domain"
+                              | "proof_received"
+                              | "verified_by_coop_mediation_numerique"
+                              | "bypassed"
+                              | "domain_not_verified_yet"
+                              | "no_validation_means_available"
+                              | "no_verification_means_for_entreprise_unipersonnelle"
+                              | "no_verification_means_for_small_association"
+                              | "no_verification_means_for_small_organization"
+                              | undefined;
+                          }>;
+                          outputFormat: "json";
+                          status: 400;
                         };
-                      } & {
-                        form: {
-                          add_member: "AS_INTERNAL" | "AS_EXTERNAL";
-                          add_domain?: string | undefined;
-                          send_notification?: string | undefined;
-                          verification_type?:
-                            | "domain"
-                            | "organization_dirigeant"
-                            | "code_sent_to_official_contact_email"
-                            | "imported_from_coop_mediation_numerique"
-                            | "imported_from_inclusion_connect"
-                            | "in_liste_dirigeants_rna"
-                            | "in_liste_dirigeants_rne"
-                            | "official_contact_email"
-                            | "ordre_professionnel_domain"
-                            | "proof_received"
-                            | "verified_by_coop_mediation_numerique"
-                            | "bypassed"
-                            | "domain_not_verified_yet"
-                            | "no_validation_means_available"
-                            | "no_verification_means_for_entreprise_unipersonnelle"
-                            | "no_verification_means_for_small_association"
-                            | undefined;
-                        };
-                      };
-                      output: {};
-                      outputFormat: string;
-                      status: import("hono/utils/http-status").StatusCode;
-                    };
                   };
                 },
                 "/validate"
@@ -641,36 +955,118 @@ declare const app: import("hono/hono-base").HonoBase<
             | import("hono/types").MergeSchemaPath<
                 {
                   "/reason/:response_id": {
-                    $get: {
-                      input: {
-                        param: {
-                          id: string;
-                          response_id: string;
+                    $get:
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                              response_id: string;
+                            };
+                          };
+                          output: string;
+                          outputFormat: "text";
+                          status: import("hono/utils/http-status").ContentfulStatusCode;
+                        }
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                              response_id: string;
+                            };
+                          };
+                          output: import("zod").ZodSafeParseError<{
+                            id: number;
+                            response_id: number;
+                          }>;
+                          outputFormat: "json";
+                          status: 400;
                         };
-                      };
-                      output: string;
-                      outputFormat: "text";
-                      status: import("hono/utils/http-status").ContentfulStatusCode;
-                    };
                   };
                 } & {
                   "/": {
-                    $patch: {
-                      input: {
-                        param: {
-                          id: string;
+                    $patch:
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                            };
+                          } & {
+                            form: {
+                              message:
+                                | import("hono/types").ParsedFormValue
+                                | import("hono/types").ParsedFormValue[];
+                              subject:
+                                | import("hono/types").ParsedFormValue
+                                | import("hono/types").ParsedFormValue[];
+                              end_user_reason:
+                                | import("hono/types").ParsedFormValue
+                                | import("hono/types").ParsedFormValue[];
+                              allow_editing:
+                                | import("hono/types").ParsedFormValue
+                                | import("hono/types").ParsedFormValue[];
+                            };
+                          };
+                          output: "OK";
+                          outputFormat: "text";
+                          status: 200;
+                        }
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                            };
+                          } & {
+                            form: {
+                              message:
+                                | import("hono/types").ParsedFormValue
+                                | import("hono/types").ParsedFormValue[];
+                              subject:
+                                | import("hono/types").ParsedFormValue
+                                | import("hono/types").ParsedFormValue[];
+                              end_user_reason:
+                                | import("hono/types").ParsedFormValue
+                                | import("hono/types").ParsedFormValue[];
+                              allow_editing:
+                                | import("hono/types").ParsedFormValue
+                                | import("hono/types").ParsedFormValue[];
+                            };
+                          };
+                          output: import("zod").ZodSafeParseError<{
+                            id: number;
+                          }>;
+                          outputFormat: "json";
+                          status: 400;
+                        }
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                            };
+                          } & {
+                            form: {
+                              message:
+                                | import("hono/types").ParsedFormValue
+                                | import("hono/types").ParsedFormValue[];
+                              subject:
+                                | import("hono/types").ParsedFormValue
+                                | import("hono/types").ParsedFormValue[];
+                              end_user_reason:
+                                | import("hono/types").ParsedFormValue
+                                | import("hono/types").ParsedFormValue[];
+                              allow_editing:
+                                | import("hono/types").ParsedFormValue
+                                | import("hono/types").ParsedFormValue[];
+                            };
+                          };
+                          output: import("zod").ZodSafeParseError<{
+                            message: string;
+                            subject: string;
+                            end_user_reason: string;
+                            allow_editing: boolean;
+                          }>;
+                          outputFormat: "json";
+                          status: 400;
                         };
-                      } & {
-                        form: {
-                          message: string;
-                          reason: string;
-                          subject: string;
-                        };
-                      };
-                      output: "OK";
-                      outputFormat: "text";
-                      status: 200;
-                    };
                   };
                 },
                 "/rejected"
@@ -678,16 +1074,29 @@ declare const app: import("hono/hono-base").HonoBase<
             | import("hono/types").MergeSchemaPath<
                 {
                   "/": {
-                    $patch: {
-                      input: {
-                        param: {
-                          id: string;
+                    $patch:
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                            };
+                          };
+                          output: import("zod").ZodSafeParseError<{
+                            id: number;
+                          }>;
+                          outputFormat: "json";
+                          status: 400;
+                        }
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                            };
+                          };
+                          output: {};
+                          outputFormat: string;
+                          status: import("hono/utils/http-status").StatusCode;
                         };
-                      };
-                      output: {};
-                      outputFormat: string;
-                      status: import("hono/utils/http-status").StatusCode;
-                    };
                   };
                 },
                 "/processed"
@@ -695,16 +1104,29 @@ declare const app: import("hono/hono-base").HonoBase<
             | import("hono/types").MergeSchemaPath<
                 {
                   "/": {
-                    $patch: {
-                      input: {
-                        param: {
-                          id: string;
+                    $patch:
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                            };
+                          };
+                          output: import("zod").ZodSafeParseError<{
+                            id: number;
+                          }>;
+                          outputFormat: "json";
+                          status: 400;
+                        }
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                            };
+                          };
+                          output: "OK";
+                          outputFormat: "text";
+                          status: 200;
                         };
-                      };
-                      output: "OK";
-                      outputFormat: "text";
-                      status: 200;
-                    };
                   };
                 },
                 "/reprocess"
@@ -756,17 +1178,32 @@ declare const app: import("hono/hono-base").HonoBase<
             };
           } & {
             "/": {
-              $post: {
-                input: {
-                  form: {
-                    email: string;
-                    role: string;
+              $post:
+                | {
+                    input: {
+                      form: {
+                        email: string;
+                        role: string;
+                      };
+                    };
+                    output: import("zod").ZodSafeParseError<{
+                      email: string;
+                      role: string;
+                    }>;
+                    outputFormat: "json";
+                    status: 400;
+                  }
+                | {
+                    input: {
+                      form: {
+                        email: string;
+                        role: string;
+                      };
+                    };
+                    output: "OK";
+                    outputFormat: "text";
+                    status: 200;
                   };
-                };
-                output: "OK";
-                outputFormat: "text";
-                status: 200;
-              };
             };
           } & {
             "/:id": {
@@ -784,6 +1221,38 @@ declare const app: import("hono/hono-base").HonoBase<
                     output: "OK";
                     outputFormat: "text";
                     status: 200;
+                  }
+                | {
+                    input: {
+                      param: {
+                        id: string;
+                      };
+                    } & {
+                      form: {
+                        role: string;
+                      };
+                    };
+                    output: import("zod").ZodSafeParseError<{
+                      id: number;
+                    }>;
+                    outputFormat: "json";
+                    status: 400;
+                  }
+                | {
+                    input: {
+                      param: {
+                        id: string;
+                      };
+                    } & {
+                      form: {
+                        role: string;
+                      };
+                    };
+                    output: import("zod").ZodSafeParseError<{
+                      role: string;
+                    }>;
+                    outputFormat: "json";
+                    status: 400;
                   }
                 | {
                     input: {
@@ -819,6 +1288,18 @@ declare const app: import("hono/hono-base").HonoBase<
                         id: string;
                       };
                     };
+                    output: import("zod").ZodSafeParseError<{
+                      id: number;
+                    }>;
+                    outputFormat: "json";
+                    status: 400;
+                  }
+                | {
+                    input: {
+                      param: {
+                        id: string;
+                      };
+                    };
                     output: "Forbidden: cannot disable yourself";
                     outputFormat: "text";
                     status: 403;
@@ -826,16 +1307,29 @@ declare const app: import("hono/hono-base").HonoBase<
             };
           } & {
             "/:id/enable": {
-              $patch: {
-                input: {
-                  param: {
-                    id: string;
+              $patch:
+                | {
+                    input: {
+                      param: {
+                        id: string;
+                      };
+                    };
+                    output: "OK";
+                    outputFormat: "text";
+                    status: 200;
+                  }
+                | {
+                    input: {
+                      param: {
+                        id: string;
+                      };
+                    };
+                    output: import("zod").ZodSafeParseError<{
+                      id: number;
+                    }>;
+                    outputFormat: "json";
+                    status: 400;
                   };
-                };
-                output: "OK";
-                outputFormat: "text";
-                status: 200;
-              };
             };
           },
           "/team"
@@ -848,103 +1342,223 @@ declare const app: import("hono/hono-base").HonoBase<
         | import("hono/types").MergeSchemaPath<
             | ({
                 "/": {
-                  $get: {
-                    input: {
-                      param: {
-                        id: string;
+                  $get:
+                    | {
+                        input: {
+                          param: {
+                            id: string;
+                          };
+                        };
+                        output: import("zod").ZodSafeParseError<{
+                          id: number;
+                        }>;
+                        outputFormat: "json";
+                        status: 400;
+                      }
+                    | {
+                        input: {
+                          param: {
+                            id: string;
+                          };
+                        };
+                        output: {};
+                        outputFormat: string;
+                        status: import("hono/utils/http-status").StatusCode;
                       };
-                    };
-                    output: {};
-                    outputFormat: string;
-                    status: import("hono/utils/http-status").StatusCode;
-                  };
                 };
               } & {
                 "/": {
-                  $delete: {
-                    input: {
-                      param: {
-                        id: string;
+                  $delete:
+                    | {
+                        input: {
+                          param: {
+                            id: string;
+                          };
+                        };
+                        output: import("zod").ZodSafeParseError<{
+                          id: number;
+                        }>;
+                        outputFormat: "json";
+                        status: 400;
+                      }
+                    | {
+                        input: {
+                          param: {
+                            id: string;
+                          };
+                        };
+                        output: "OK";
+                        outputFormat: "text";
+                        status: 200;
                       };
-                    };
-                    output: "OK";
-                    outputFormat: "text";
-                    status: 200;
-                  };
                 };
               } & {
                 "/reset/email_verified": {
-                  $patch: {
-                    input: {
-                      param: {
-                        id: string;
+                  $patch:
+                    | {
+                        input: {
+                          param: {
+                            id: string;
+                          };
+                        };
+                        output: "OK";
+                        outputFormat: "text";
+                        status: 200;
+                      }
+                    | {
+                        input: {
+                          param: {
+                            id: string;
+                          };
+                        };
+                        output: import("zod").ZodSafeParseError<{
+                          id: number;
+                        }>;
+                        outputFormat: "json";
+                        status: 400;
                       };
-                    };
-                    output: "OK";
-                    outputFormat: "text";
-                    status: 200;
-                  };
                 };
               } & {
                 "/reset/france_connect": {
-                  $patch: {
-                    input: {
-                      param: {
-                        id: string;
+                  $patch:
+                    | {
+                        input: {
+                          param: {
+                            id: string;
+                          };
+                        };
+                        output: "OK";
+                        outputFormat: "text";
+                        status: 200;
+                      }
+                    | {
+                        input: {
+                          param: {
+                            id: string;
+                          };
+                        };
+                        output: import("zod").ZodSafeParseError<{
+                          id: number;
+                        }>;
+                        outputFormat: "json";
+                        status: 400;
                       };
-                    };
-                    output: "OK";
-                    outputFormat: "text";
-                    status: 200;
-                  };
                 };
               } & {
                 "/reset/password": {
-                  $patch: {
-                    input: {
-                      param: {
-                        id: string;
+                  $patch:
+                    | {
+                        input: {
+                          param: {
+                            id: string;
+                          };
+                        };
+                        output: "OK";
+                        outputFormat: "text";
+                        status: 200;
+                      }
+                    | {
+                        input: {
+                          param: {
+                            id: string;
+                          };
+                        };
+                        output: import("zod").ZodSafeParseError<{
+                          id: number;
+                        }>;
+                        outputFormat: "json";
+                        status: 400;
                       };
-                    };
-                    output: "OK";
-                    outputFormat: "text";
-                    status: 200;
-                  };
                 };
               } & {
                 "/reset/mfa": {
-                  $patch: {
-                    input: {
-                      param: {
-                        id: string;
+                  $patch:
+                    | {
+                        input: {
+                          param: {
+                            id: string;
+                          };
+                        };
+                        output: "OK";
+                        outputFormat: "text";
+                        status: 200;
+                      }
+                    | {
+                        input: {
+                          param: {
+                            id: string;
+                          };
+                        };
+                        output: import("zod").ZodSafeParseError<{
+                          id: number;
+                        }>;
+                        outputFormat: "json";
+                        status: 400;
                       };
-                    };
-                    output: "OK";
-                    outputFormat: "text";
-                    status: 200;
-                  };
                 };
               })
             | import("hono/types").MergeSchemaPath<
                 {
                   "/": {
-                    $get: {
-                      input: {
-                        param: {
-                          id: string;
+                    $get:
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                            };
+                          } & {
+                            query: {
+                              describedby: string | string[];
+                              page_ref: string | string[];
+                              page?: string | string[] | undefined;
+                              page_size?: string | string[] | undefined;
+                            };
+                          };
+                          output: {};
+                          outputFormat: string;
+                          status: import("hono/utils/http-status").StatusCode;
+                        }
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                            };
+                          } & {
+                            query: {
+                              describedby: string | string[];
+                              page_ref: string | string[];
+                              page?: string | string[] | undefined;
+                              page_size?: string | string[] | undefined;
+                            };
+                          };
+                          output: import("zod").ZodSafeParseError<{
+                            id: number;
+                          }>;
+                          outputFormat: "json";
+                          status: 400;
+                        }
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                            };
+                          } & {
+                            query: {
+                              describedby: string | string[];
+                              page_ref: string | string[];
+                              page?: string | string[] | undefined;
+                              page_size?: string | string[] | undefined;
+                            };
+                          };
+                          output: import("zod").ZodSafeParseError<{
+                            page: number;
+                            page_size: number;
+                            describedby: string;
+                            page_ref: string;
+                          }>;
+                          outputFormat: "json";
+                          status: 400;
                         };
-                      } & {
-                        query: {
-                          describedby: string | string[];
-                          page_ref: string | string[];
-                          page?: string | string[] | undefined;
-                          page_size?: string | string[] | undefined;
-                        };
-                      };
-                      output: {};
-                      outputFormat: string;
-                      status: import("hono/utils/http-status").StatusCode;
-                    };
                   };
                 },
                 "/organizations"
@@ -952,23 +1566,110 @@ declare const app: import("hono/hono-base").HonoBase<
             | import("hono/types").MergeSchemaPath<
                 {
                   "/": {
-                    $get: {
-                      input: {
-                        param: {
-                          id: string;
+                    $get:
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                            };
+                          } & {
+                            query: {
+                              describedby: string;
+                            };
+                          };
+                          output: {};
+                          outputFormat: string;
+                          status: import("hono/utils/http-status").StatusCode;
+                        }
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                            };
+                          } & {
+                            query: {
+                              describedby: string;
+                            };
+                          };
+                          output: import("zod").ZodSafeParseError<{
+                            id: number;
+                          }>;
+                          outputFormat: "json";
+                          status: 400;
+                        }
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                            };
+                          } & {
+                            query: {
+                              describedby: string;
+                            };
+                          };
+                          output: import("zod").ZodSafeParseError<{
+                            describedby: string;
+                          }>;
+                          outputFormat: "json";
+                          status: 400;
                         };
-                      } & {
-                        query: {
-                          describedby: string;
-                        };
-                      };
-                      output: {};
-                      outputFormat: string;
-                      status: import("hono/utils/http-status").StatusCode;
-                    };
                   };
                 },
                 "/moderations"
+              >
+            | import("hono/types").MergeSchemaPath<
+                {
+                  "/": {
+                    $get:
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                            };
+                          } & {
+                            query: {
+                              describedby: string;
+                            };
+                          };
+                          output: {};
+                          outputFormat: string;
+                          status: import("hono/utils/http-status").StatusCode;
+                        }
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                            };
+                          } & {
+                            query: {
+                              describedby: string;
+                            };
+                          };
+                          output: import("zod").ZodSafeParseError<{
+                            id: number;
+                          }>;
+                          outputFormat: "json";
+                          status: 400;
+                        }
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                            };
+                          } & {
+                            query: {
+                              describedby: string;
+                            };
+                          };
+                          output: import("zod").ZodSafeParseError<{
+                            describedby: string;
+                          }>;
+                          outputFormat: "json";
+                          status: 400;
+                        };
+                  };
+                },
+                "/oidc_clients"
               >,
             "/:id"
           >
@@ -1009,17 +1710,32 @@ declare const app: import("hono/hono-base").HonoBase<
         | import("hono/types").MergeSchemaPath<
             {
               "/": {
-                $get: {
-                  input: {
-                    query: {
-                      siret: string;
-                      retry?: string | undefined;
+                $get:
+                  | {
+                      input: {
+                        query: {
+                          siret: string;
+                          retry?: string | undefined;
+                        };
+                      };
+                      output: {};
+                      outputFormat: string;
+                      status: import("hono/utils/http-status").StatusCode;
+                    }
+                  | {
+                      input: {
+                        query: {
+                          siret: string;
+                          retry?: string | undefined;
+                        };
+                      };
+                      output: import("zod").ZodSafeParseError<{
+                        siret: string;
+                        retry?: string | undefined;
+                      }>;
+                      outputFormat: "json";
+                      status: 400;
                     };
-                  };
-                  output: {};
-                  outputFormat: string;
-                  status: import("hono/utils/http-status").StatusCode;
-                };
               };
             },
             "/leaders"
@@ -1068,112 +1784,318 @@ declare const app: import("hono/hono-base").HonoBase<
         | import("hono/types").MergeSchemaPath<
             | {
                 "/": {
-                  $get: {
-                    input: {
-                      param: {
-                        id: string;
+                  $get:
+                    | {
+                        input: {
+                          param: {
+                            id: string;
+                          };
+                        };
+                        output: import("zod").ZodSafeParseError<{
+                          id: number;
+                        }>;
+                        outputFormat: "json";
+                        status: 400;
+                      }
+                    | {
+                        input: {
+                          param: {
+                            id: string;
+                          };
+                        };
+                        output: {};
+                        outputFormat: string;
+                        status: import("hono/utils/http-status").StatusCode;
                       };
-                    };
-                    output: {};
-                    outputFormat: string;
-                    status: import("hono/utils/http-status").StatusCode;
-                  };
                 };
               }
             | import("hono/types").MergeSchemaPath<
                 | {
                     "/": {
-                      $get: {
-                        input: {
-                          param: {
-                            id: string;
+                      $get:
+                        | {
+                            input: {
+                              param: {
+                                id: string;
+                              };
+                            } & {
+                              query: {
+                                describedby: string | string[];
+                                page_ref: string | string[];
+                                page?: string | string[] | undefined;
+                                page_size?: string | string[] | undefined;
+                              };
+                            };
+                            output: {};
+                            outputFormat: string;
+                            status: import("hono/utils/http-status").StatusCode;
+                          }
+                        | {
+                            input: {
+                              param: {
+                                id: string;
+                              };
+                            } & {
+                              query: {
+                                describedby: string | string[];
+                                page_ref: string | string[];
+                                page?: string | string[] | undefined;
+                                page_size?: string | string[] | undefined;
+                              };
+                            };
+                            output: import("zod").ZodSafeParseError<{
+                              id: number;
+                            }>;
+                            outputFormat: "json";
+                            status: 400;
+                          }
+                        | {
+                            input: {
+                              param: {
+                                id: string;
+                              };
+                            } & {
+                              query: {
+                                describedby: string | string[];
+                                page_ref: string | string[];
+                                page?: string | string[] | undefined;
+                                page_size?: string | string[] | undefined;
+                              };
+                            };
+                            output: import("zod").ZodSafeParseError<{
+                              page: number;
+                              page_size: number;
+                              describedby: string;
+                              page_ref: string;
+                            }>;
+                            outputFormat: "json";
+                            status: 400;
                           };
-                        } & {
-                          query: {
-                            describedby: string | string[];
-                            page_ref: string | string[];
-                            page?: string | string[] | undefined;
-                            page_size?: string | string[] | undefined;
-                          };
-                        };
-                        output: {};
-                        outputFormat: string;
-                        status: import("hono/utils/http-status").StatusCode;
-                      };
                     };
                   }
                 | (import("hono/types").MergeSchemaPath<
                     {
                       "/": {
-                        $patch: {
-                          input: {
-                            param: {
-                              id: string;
-                              user_id: string;
+                        $patch:
+                          | {
+                              input: {
+                                param: {
+                                  id: string;
+                                  user_id: string;
+                                };
+                              } & {
+                                form: {
+                                  verification_type?:
+                                    | "domain"
+                                    | "organization_dirigeant"
+                                    | "code_sent_to_official_contact_email"
+                                    | "imported_from_coop_mediation_numerique"
+                                    | "imported_from_inclusion_connect"
+                                    | "in_liste_dirigeants_rna"
+                                    | "in_liste_dirigeants_rne"
+                                    | "official_contact_email"
+                                    | "ordre_professionnel_domain"
+                                    | "proof_received"
+                                    | "verified_by_coop_mediation_numerique"
+                                    | "bypassed"
+                                    | "domain_not_verified_yet"
+                                    | "no_validation_means_available"
+                                    | "no_verification_means_for_entreprise_unipersonnelle"
+                                    | "no_verification_means_for_small_association"
+                                    | "no_verification_means_for_small_organization"
+                                    | undefined;
+                                  is_external?: string | undefined;
+                                };
+                              };
+                              output: "OK";
+                              outputFormat: "text";
+                              status: 200;
+                            }
+                          | {
+                              input: {
+                                param: {
+                                  id: string;
+                                  user_id: string;
+                                };
+                              } & {
+                                form: {
+                                  verification_type?:
+                                    | "domain"
+                                    | "organization_dirigeant"
+                                    | "code_sent_to_official_contact_email"
+                                    | "imported_from_coop_mediation_numerique"
+                                    | "imported_from_inclusion_connect"
+                                    | "in_liste_dirigeants_rna"
+                                    | "in_liste_dirigeants_rne"
+                                    | "official_contact_email"
+                                    | "ordre_professionnel_domain"
+                                    | "proof_received"
+                                    | "verified_by_coop_mediation_numerique"
+                                    | "bypassed"
+                                    | "domain_not_verified_yet"
+                                    | "no_validation_means_available"
+                                    | "no_verification_means_for_entreprise_unipersonnelle"
+                                    | "no_verification_means_for_small_association"
+                                    | "no_verification_means_for_small_organization"
+                                    | undefined;
+                                  is_external?: string | undefined;
+                                };
+                              };
+                              output: import("zod").ZodSafeParseError<{
+                                id: number;
+                                user_id: number;
+                              }>;
+                              outputFormat: "json";
+                              status: 400;
+                            }
+                          | {
+                              input: {
+                                param: {
+                                  id: string;
+                                  user_id: string;
+                                };
+                              } & {
+                                form: {
+                                  verification_type?:
+                                    | "domain"
+                                    | "organization_dirigeant"
+                                    | "code_sent_to_official_contact_email"
+                                    | "imported_from_coop_mediation_numerique"
+                                    | "imported_from_inclusion_connect"
+                                    | "in_liste_dirigeants_rna"
+                                    | "in_liste_dirigeants_rne"
+                                    | "official_contact_email"
+                                    | "ordre_professionnel_domain"
+                                    | "proof_received"
+                                    | "verified_by_coop_mediation_numerique"
+                                    | "bypassed"
+                                    | "domain_not_verified_yet"
+                                    | "no_validation_means_available"
+                                    | "no_verification_means_for_entreprise_unipersonnelle"
+                                    | "no_verification_means_for_small_association"
+                                    | "no_verification_means_for_small_organization"
+                                    | undefined;
+                                  is_external?: string | undefined;
+                                };
+                              };
+                              output: import("zod").ZodSafeParseError<{
+                                verification_type?:
+                                  | "domain"
+                                  | "organization_dirigeant"
+                                  | "code_sent_to_official_contact_email"
+                                  | "imported_from_coop_mediation_numerique"
+                                  | "imported_from_inclusion_connect"
+                                  | "in_liste_dirigeants_rna"
+                                  | "in_liste_dirigeants_rne"
+                                  | "official_contact_email"
+                                  | "ordre_professionnel_domain"
+                                  | "proof_received"
+                                  | "verified_by_coop_mediation_numerique"
+                                  | "bypassed"
+                                  | "domain_not_verified_yet"
+                                  | "no_validation_means_available"
+                                  | "no_verification_means_for_entreprise_unipersonnelle"
+                                  | "no_verification_means_for_small_association"
+                                  | "no_verification_means_for_small_organization"
+                                  | undefined;
+                                is_external?: boolean | undefined;
+                              }>;
+                              outputFormat: "json";
+                              status: 400;
                             };
-                          } & {
-                            form: {
-                              verification_type?:
-                                | "domain"
-                                | "organization_dirigeant"
-                                | "code_sent_to_official_contact_email"
-                                | "imported_from_coop_mediation_numerique"
-                                | "imported_from_inclusion_connect"
-                                | "in_liste_dirigeants_rna"
-                                | "in_liste_dirigeants_rne"
-                                | "official_contact_email"
-                                | "ordre_professionnel_domain"
-                                | "proof_received"
-                                | "verified_by_coop_mediation_numerique"
-                                | "bypassed"
-                                | "domain_not_verified_yet"
-                                | "no_validation_means_available"
-                                | "no_verification_means_for_entreprise_unipersonnelle"
-                                | "no_verification_means_for_small_association"
-                                | undefined;
-                              is_external?: string | undefined;
-                            };
-                          };
-                          output: "OK";
-                          outputFormat: "text";
-                          status: 200;
-                        };
                       };
                     } & {
                       "/": {
-                        $delete: {
-                          input: {
-                            param: {
-                              id: string;
-                              user_id: string;
+                        $delete:
+                          | {
+                              input: {
+                                param: {
+                                  id: string;
+                                  user_id: string;
+                                };
+                              };
+                              output: "OK";
+                              outputFormat: "text";
+                              status: 200;
+                            }
+                          | {
+                              input: {
+                                param: {
+                                  id: string;
+                                  user_id: string;
+                                };
+                              };
+                              output: import("zod").ZodSafeParseError<{
+                                id: number;
+                                user_id: number;
+                              }>;
+                              outputFormat: "json";
+                              status: 400;
                             };
-                          };
-                          output: "OK";
-                          outputFormat: "text";
-                          status: 200;
-                        };
                       };
                     },
                     "/:user_id"
                   > & {
                     "/": {
-                      $get: {
-                        input: {
-                          param: {
-                            id: string;
+                      $get:
+                        | {
+                            input: {
+                              param: {
+                                id: string;
+                              };
+                            } & {
+                              query: {
+                                describedby: string | string[];
+                                page_ref: string | string[];
+                                page?: string | string[] | undefined;
+                                page_size?: string | string[] | undefined;
+                              };
+                            };
+                            output: {};
+                            outputFormat: string;
+                            status: import("hono/utils/http-status").StatusCode;
+                          }
+                        | {
+                            input: {
+                              param: {
+                                id: string;
+                              };
+                            } & {
+                              query: {
+                                describedby: string | string[];
+                                page_ref: string | string[];
+                                page?: string | string[] | undefined;
+                                page_size?: string | string[] | undefined;
+                              };
+                            };
+                            output: import("zod").ZodSafeParseError<{
+                              id: number;
+                            }>;
+                            outputFormat: "json";
+                            status: 400;
+                          }
+                        | {
+                            input: {
+                              param: {
+                                id: string;
+                              };
+                            } & {
+                              query: {
+                                describedby: string | string[];
+                                page_ref: string | string[];
+                                page?: string | string[] | undefined;
+                                page_size?: string | string[] | undefined;
+                              };
+                            };
+                            output: import("zod").ZodSafeParseError<{
+                              page: number;
+                              page_size: number;
+                              describedby: string;
+                              page_ref: string;
+                            }>;
+                            outputFormat: "json";
+                            status: 400;
                           };
-                        } & {
-                          query: {
-                            describedby: string | string[];
-                            page_ref: string | string[];
-                            page?: string | string[] | undefined;
-                            page_size?: string | string[] | undefined;
-                          };
-                        };
-                        output: {};
-                        outputFormat: string;
-                        status: import("hono/utils/http-status").StatusCode;
-                      };
                     };
                   }),
                 "/members"
@@ -1181,69 +2103,186 @@ declare const app: import("hono/hono-base").HonoBase<
             | import("hono/types").MergeSchemaPath<
                 {
                   "/": {
-                    $get: {
-                      input: {
-                        param: {
-                          id: string;
+                    $get:
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                            };
+                          } & {
+                            query: {
+                              describedby: string;
+                            };
+                          };
+                          output: {};
+                          outputFormat: string;
+                          status: import("hono/utils/http-status").StatusCode;
+                        }
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                            };
+                          } & {
+                            query: {
+                              describedby: string;
+                            };
+                          };
+                          output: import("zod").ZodSafeParseError<{
+                            id: number;
+                          }>;
+                          outputFormat: "json";
+                          status: 400;
+                        }
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                            };
+                          } & {
+                            query: {
+                              describedby: string;
+                            };
+                          };
+                          output: import("zod").ZodSafeParseError<{
+                            describedby: string;
+                          }>;
+                          outputFormat: "json";
+                          status: 400;
                         };
-                      } & {
-                        query: {
-                          describedby: string;
-                        };
-                      };
-                      output: {};
-                      outputFormat: string;
-                      status: import("hono/utils/http-status").StatusCode;
-                    };
                   };
                 } & {
                   "/": {
-                    $put: {
-                      input: {
-                        param: {
-                          id: string;
+                    $put:
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                            };
+                          } & {
+                            form: {
+                              domain: string;
+                            };
+                          };
+                          output: "OK";
+                          outputFormat: "text";
+                          status: 200;
+                        }
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                            };
+                          } & {
+                            form: {
+                              domain: string;
+                            };
+                          };
+                          output: import("zod").ZodSafeParseError<{
+                            id: number;
+                          }>;
+                          outputFormat: "json";
+                          status: 400;
+                        }
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                            };
+                          } & {
+                            form: {
+                              domain: string;
+                            };
+                          };
+                          output: import("zod").ZodSafeParseError<{
+                            domain: string;
+                          }>;
+                          outputFormat: "json";
+                          status: 400;
                         };
-                      } & {
-                        form: {
-                          domain: string;
-                        };
-                      };
-                      output: "OK";
-                      outputFormat: "text";
-                      status: 200;
-                    };
                   };
                 } & {
                   "/:domain_id": {
-                    $delete: {
-                      input: {
-                        param: {
-                          id: string;
-                          domain_id: string;
+                    $delete:
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                              domain_id: string;
+                            };
+                          };
+                          output: "OK";
+                          outputFormat: "text";
+                          status: 200;
+                        }
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                              domain_id: string;
+                            };
+                          };
+                          output: import("zod").ZodSafeParseError<{
+                            id: number;
+                            domain_id: number;
+                          }>;
+                          outputFormat: "json";
+                          status: 400;
                         };
-                      };
-                      output: "OK";
-                      outputFormat: "text";
-                      status: 200;
-                    };
                   };
                 } & {
                   "/:domain_id": {
-                    $patch: {
-                      input: {
-                        param: {
-                          id: string;
-                          domain_id: string;
+                    $patch:
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                              domain_id: string;
+                            };
+                          } & {
+                            query: {
+                              type: "external" | "verified" | "refused";
+                            };
+                          };
+                          output: "OK";
+                          outputFormat: "text";
+                          status: 200;
+                        }
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                              domain_id: string;
+                            };
+                          } & {
+                            query: {
+                              type: "external" | "verified" | "refused";
+                            };
+                          };
+                          output: import("zod").ZodSafeParseError<{
+                            id: number;
+                            domain_id: number;
+                          }>;
+                          outputFormat: "json";
+                          status: 400;
+                        }
+                      | {
+                          input: {
+                            param: {
+                              id: string;
+                              domain_id: string;
+                            };
+                          } & {
+                            query: {
+                              type: "external" | "verified" | "refused";
+                            };
+                          };
+                          output: import("zod").ZodSafeParseError<{
+                            type: "external" | "verified" | "refused";
+                          }>;
+                          outputFormat: "json";
+                          status: 400;
                         };
-                      } & {
-                        query: {
-                          type: "external" | "verified" | "refused";
-                        };
-                      };
-                      output: "OK";
-                      outputFormat: "text";
-                      status: 200;
-                    };
                   };
                 },
                 "/domains"
@@ -1252,19 +2291,38 @@ declare const app: import("hono/hono-base").HonoBase<
           >
       ) & {
         "/": {
-          $get: {
-            input: {
-              query: {
-                page?: string | string[] | undefined;
-                page_size?: string | string[] | undefined;
-                q?: string | undefined;
-                id?: string | undefined;
+          $get:
+            | {
+                input: {
+                  query: {
+                    page?: string | string[] | undefined;
+                    page_size?: string | string[] | undefined;
+                    q?: string | undefined;
+                    id?: string | undefined;
+                  };
+                };
+                output: {};
+                outputFormat: string;
+                status: import("hono/utils/http-status").StatusCode;
+              }
+            | {
+                input: {
+                  query: {
+                    page?: string | string[] | undefined;
+                    page_size?: string | string[] | undefined;
+                    q?: string | undefined;
+                    id?: string | undefined;
+                  };
+                };
+                output: import("zod").ZodSafeParseError<{
+                  page: number;
+                  page_size: number;
+                  q: string;
+                  id?: number | undefined;
+                }>;
+                outputFormat: "json";
+                status: 400;
               };
-            };
-            output: {};
-            outputFormat: string;
-            status: import("hono/utils/http-status").StatusCode;
-          };
         };
       },
       "/organizations"
@@ -1281,16 +2339,29 @@ declare const app: import("hono/hono-base").HonoBase<
         };
       } & {
         "/": {
-          $put: {
-            input: {
-              form: {
-                problematic_email: string;
+          $put:
+            | {
+                input: {
+                  form: {
+                    problematic_email: string;
+                  };
+                };
+                output: {};
+                outputFormat: string;
+                status: import("hono/utils/http-status").StatusCode;
+              }
+            | {
+                input: {
+                  form: {
+                    problematic_email: string;
+                  };
+                };
+                output: import("zod").ZodSafeParseError<{
+                  problematic_email: string;
+                }>;
+                outputFormat: "json";
+                status: 400;
               };
-            };
-            output: {};
-            outputFormat: string;
-            status: import("hono/utils/http-status").StatusCode;
-          };
         };
       } & {
         "/:email_domain": {
@@ -1304,6 +2375,18 @@ declare const app: import("hono/hono-base").HonoBase<
                 output: "OK";
                 outputFormat: "text";
                 status: 200;
+              }
+            | {
+                input: {
+                  param: {
+                    email_domain: string;
+                  };
+                };
+                output: import("zod").ZodSafeParseError<{
+                  email_domain: string;
+                }>;
+                outputFormat: "json";
+                status: 400;
               }
             | {
                 input: {
@@ -1340,17 +2423,38 @@ declare const app: import("hono/hono-base").HonoBase<
         };
       } & {
         "/": {
-          $post: {
-            input: {
-              form: {
-                label: string;
-                content: string;
+          $post:
+            | {
+                input: {
+                  form: {
+                    label: string;
+                    content: string;
+                    end_user_reason: string;
+                    allow_editing?: string | undefined;
+                  };
+                };
+                output: import("zod").ZodSafeParseError<{
+                  label: string;
+                  content: string;
+                  end_user_reason: string;
+                  allow_editing: boolean;
+                }>;
+                outputFormat: "json";
+                status: 400;
+              }
+            | {
+                input: {
+                  form: {
+                    label: string;
+                    content: string;
+                    end_user_reason: string;
+                    allow_editing?: string | undefined;
+                  };
+                };
+                output: undefined;
+                outputFormat: "redirect";
+                status: 303;
               };
-            };
-            output: undefined;
-            outputFormat: "redirect";
-            status: 303;
-          };
         };
       } & {
         "/:id": {
@@ -1367,21 +2471,46 @@ declare const app: import("hono/hono-base").HonoBase<
         };
       } & {
         "/:id": {
-          $patch: {
-            input: {
-              form: {
-                label: string;
-                content: string;
+          $patch:
+            | {
+                input: {
+                  form: {
+                    label: string;
+                    content: string;
+                    end_user_reason: string;
+                    allow_editing?: string | undefined;
+                  };
+                } & {
+                  param: {
+                    id: string;
+                  };
+                };
+                output: import("zod").ZodSafeParseError<{
+                  label: string;
+                  content: string;
+                  end_user_reason: string;
+                  allow_editing: boolean;
+                }>;
+                outputFormat: "json";
+                status: 400;
+              }
+            | {
+                input: {
+                  form: {
+                    label: string;
+                    content: string;
+                    end_user_reason: string;
+                    allow_editing?: string | undefined;
+                  };
+                } & {
+                  param: {
+                    id: string;
+                  };
+                };
+                output: "";
+                outputFormat: "text";
+                status: 200;
               };
-            } & {
-              param: {
-                id: string;
-              };
-            };
-            output: "";
-            outputFormat: "text";
-            status: 200;
-          };
         };
       } & {
         "/:id": {

--- a/sources/web/src/routes/users/:id/index.tsx
+++ b/sources/web/src/routes/users/:id/index.tsx
@@ -17,6 +17,7 @@ import { get_franceconnect_by_user_id } from "./get_franceconnect_by_user_id.que
 import { get_user_by_id } from "./get_user_by_id.query";
 import user_moderations_route from "./moderations";
 import { UserNotFound } from "./not-found";
+import user_oidc_clients_route from "./oidc_clients";
 import user_organizations_page_route from "./organizations";
 import { UserPage } from "./page";
 
@@ -142,6 +143,7 @@ export default new Hono<AppContext>()
   )
   //
   .route("/organizations", user_organizations_page_route)
-  .route("/moderations", user_moderations_route);
+  .route("/moderations", user_moderations_route)
+  .route("/oidc_clients", user_oidc_clients_route);
 
 //

--- a/sources/web/src/routes/users/:id/oidc_clients/Table.tsx
+++ b/sources/web/src/routes/users/:id/oidc_clients/Table.tsx
@@ -1,0 +1,72 @@
+//
+
+import { table } from "#src/ui/table";
+import { LocalTime } from "#src/ui/time";
+import { urls } from "#src/urls";
+import type { get_oidc_clients_by_user_id } from "./get_oidc_clients_by_user_id.query";
+
+//
+
+type ConnectionList = Awaited<ReturnType<typeof get_oidc_clients_by_user_id>>;
+
+export function Table({
+  connections,
+  describedby,
+}: {
+  connections: ConnectionList;
+  describedby: string;
+}) {
+  return (
+    <table class={table()} aria-describedby={describedby}>
+      <thead>
+        <tr>
+          <th>Date</th>
+          <th>Service</th>
+          <th>Organisation</th>
+          <th>SP Name</th>
+        </tr>
+      </thead>
+      <tbody>
+        {connections.map((connection) => (
+          <Row key={`${connection.id}`} connection={connection} />
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+//
+
+function Row({
+  connection,
+  key,
+}: {
+  connection: ConnectionList[number];
+  key?: string;
+}) {
+  const org = connection.organization;
+  const org_href = org
+    ? urls.organizations[":id"].$url({ param: { id: org.id } }).pathname
+    : null;
+
+  return (
+    <tr class="dark:hover:bg-grey-850 hover:bg-gray-100" key={key}>
+      <td>
+        <LocalTime date={connection.created_at} />
+      </td>
+      <td>
+        <span title={connection.oidc_client.client_id}>
+          {connection.oidc_client.client_name}
+        </span>
+      </td>
+      <td>
+        {org && org_href ? (
+          <a href={org_href}>{org.cached_libelle ?? org.siret}</a>
+        ) : (
+          <span>—</span>
+        )}
+      </td>
+      <td>{connection.sp_name ?? <span>—</span>}</td>
+    </tr>
+  );
+}

--- a/sources/web/src/routes/users/:id/oidc_clients/get_oidc_clients_by_user_id.query.test.ts
+++ b/sources/web/src/routes/users/:id/oidc_clients/get_oidc_clients_by_user_id.query.test.ts
@@ -1,0 +1,93 @@
+//
+
+import {
+  create_adora_pony_oidc_connection,
+  create_adora_pony_user,
+  create_unicorn_oidc_client,
+} from "@~/identite-proconnect/database/seed/unicorn";
+import {
+  empty_database,
+  migrate,
+  pg,
+} from "@~/identite-proconnect/database/testing";
+import { beforeAll, beforeEach, expect, setSystemTime, test } from "bun:test";
+import { get_oidc_clients_by_user_id } from "./get_oidc_clients_by_user_id.query";
+
+//
+
+beforeAll(migrate);
+beforeEach(empty_database);
+setSystemTime(new Date("2222-01-01T00:00:00.000Z"));
+
+//
+
+test("get adora's oidc connections", async () => {
+  const user_id = await create_adora_pony_user(pg);
+  await create_unicorn_oidc_client(pg);
+  await create_adora_pony_oidc_connection(pg, { sp_name: "🦄 sp" });
+
+  const connections = await get_oidc_clients_by_user_id(pg, user_id);
+
+  expect(connections).toMatchInlineSnapshot(`
+    [
+      {
+        "created_at": "2222-01-01 01:00:00+01",
+        "id": 1,
+        "oidc_client": {
+          "client_id": "🦄 client_id",
+          "client_name": "🦄 client_name",
+        },
+        "organization": null,
+        "sp_name": "🦄 sp",
+      },
+    ]
+  `);
+});
+
+test("returns empty array when user has no connections", async () => {
+  const user_id = await create_adora_pony_user(pg);
+
+  const connections = await get_oidc_clients_by_user_id(pg, user_id);
+
+  expect(connections).toEqual([]);
+});
+
+test("returns connections ordered by created_at desc", async () => {
+  const user_id = await create_adora_pony_user(pg);
+  await create_unicorn_oidc_client(pg);
+  await create_adora_pony_oidc_connection(pg, {
+    created_at: "2020-01-01T00:00:00Z",
+    updated_at: "2020-01-01T00:00:00Z",
+  });
+  await create_adora_pony_oidc_connection(pg, {
+    created_at: "2024-06-01T00:00:00Z",
+    updated_at: "2024-06-01T00:00:00Z",
+  });
+
+  const connections = await get_oidc_clients_by_user_id(pg, user_id);
+
+  expect(connections).toMatchInlineSnapshot(`
+    [
+      {
+        "created_at": "2024-06-01 01:00:00+01",
+        "id": 2,
+        "oidc_client": {
+          "client_id": "🦄 client_id",
+          "client_name": "🦄 client_name",
+        },
+        "organization": null,
+        "sp_name": null,
+      },
+      {
+        "created_at": "2020-01-01 01:00:00+01",
+        "id": 1,
+        "oidc_client": {
+          "client_id": "🦄 client_id",
+          "client_name": "🦄 client_name",
+        },
+        "organization": null,
+        "sp_name": null,
+      },
+    ]
+  `);
+});

--- a/sources/web/src/routes/users/:id/oidc_clients/get_oidc_clients_by_user_id.query.ts
+++ b/sources/web/src/routes/users/:id/oidc_clients/get_oidc_clients_by_user_id.query.ts
@@ -1,0 +1,30 @@
+//
+
+import type { IdentiteProconnectPgDatabase } from "@~/identite-proconnect/database";
+import { schema } from "@~/identite-proconnect/database";
+import { desc, eq } from "drizzle-orm";
+
+//
+
+export async function get_oidc_clients_by_user_id(
+  pg: IdentiteProconnectPgDatabase,
+  user_id: number,
+) {
+  return pg.query.users_oidc_clients.findMany({
+    columns: {
+      created_at: true,
+      id: true,
+      sp_name: true,
+    },
+    orderBy: desc(schema.users_oidc_clients.created_at),
+    where: eq(schema.users_oidc_clients.user_id, user_id),
+    with: {
+      oidc_client: {
+        columns: { client_id: true, client_name: true },
+      },
+      organization: {
+        columns: { cached_libelle: true, id: true, siret: true },
+      },
+    },
+  });
+}

--- a/sources/web/src/routes/users/:id/oidc_clients/index.test.ts
+++ b/sources/web/src/routes/users/:id/oidc_clients/index.test.ts
@@ -1,0 +1,65 @@
+//
+
+import { set_userinfo } from "#src/middleware/auth";
+import { set_config } from "#src/middleware/config";
+import { set_identite_pg } from "#src/middleware/identite-pg";
+import { set_nonce } from "#src/middleware/nonce";
+import {
+  create_adora_pony_oidc_connection,
+  create_adora_pony_user,
+  create_unicorn_oidc_client,
+} from "@~/identite-proconnect/database/seed/unicorn";
+import {
+  empty_database,
+  migrate,
+  pg,
+} from "@~/identite-proconnect/database/testing";
+import { beforeAll, beforeEach, expect, setSystemTime, test } from "bun:test";
+import { Hono } from "hono";
+import app from "./index";
+
+//
+
+beforeAll(migrate);
+beforeEach(empty_database);
+setSystemTime(new Date("2222-01-01T00:00:00.000Z"));
+
+//
+
+test("GET /users/:id/oidc_clients renders connection history", async () => {
+  const user_id = await create_adora_pony_user(pg);
+  await create_unicorn_oidc_client(pg);
+  await create_adora_pony_oidc_connection(pg, { sp_name: "🦄 sp" });
+
+  const response = await new Hono()
+    .use(set_config({}))
+    .use(set_identite_pg(pg))
+    .use(set_nonce("nonce"))
+    .use(set_userinfo({ email: "test@example.com" }))
+    .route("/:id/oidc_clients", app)
+    .request(`/${user_id}/oidc_clients?describedby=test`);
+
+  const html = await response.text();
+  expect(html).toContain("Service");
+  expect(html).toContain("Organisation");
+  expect(html).toContain("🦄 client_name");
+  expect(html).toContain("🦄 sp");
+  expect(response.status).toBe(200);
+});
+
+test("GET /users/:id/oidc_clients with no connections renders empty table", async () => {
+  const user_id = await create_adora_pony_user(pg);
+
+  const response = await new Hono()
+    .use(set_config({}))
+    .use(set_identite_pg(pg))
+    .use(set_nonce("nonce"))
+    .use(set_userinfo({ email: "test@example.com" }))
+    .route("/:id/oidc_clients", app)
+    .request(`/${user_id}/oidc_clients?describedby=test`);
+
+  const html = await response.text();
+  expect(html).toContain("Service");
+  expect(html).toContain("Organisation");
+  expect(response.status).toBe(200);
+});

--- a/sources/web/src/routes/users/:id/oidc_clients/index.tsx
+++ b/sources/web/src/routes/users/:id/oidc_clients/index.tsx
@@ -1,0 +1,31 @@
+//
+
+import type { AppContext } from "#src/middleware/context";
+import { DescribedBySchema, EntitySchema } from "#src/schema";
+import { zValidator } from "@hono/zod-validator";
+import { Hono } from "hono";
+import { jsxRenderer } from "hono/jsx-renderer";
+import { get_oidc_clients_by_user_id } from "./get_oidc_clients_by_user_id.query";
+import { Table } from "./Table";
+
+//
+
+export default new Hono<AppContext>()
+  .use("/", jsxRenderer())
+  .get(
+    "/",
+    zValidator("param", EntitySchema),
+    zValidator("query", DescribedBySchema),
+    async function GET({ render, req, var: { identite_pg } }) {
+      const { id: user_id } = req.valid("param");
+      const { describedby } = req.valid("query");
+      const connections = await get_oidc_clients_by_user_id(
+        identite_pg,
+        user_id,
+      );
+
+      return render(
+        <Table connections={connections} describedby={describedby} />,
+      );
+    },
+  );

--- a/sources/web/src/routes/users/:id/page.tsx
+++ b/sources/web/src/routes/users/:id/page.tsx
@@ -31,6 +31,7 @@ export async function UserPage({
 }) {
   const $organizations_describedby = hyper_ref("user_organizations");
   const $moderations_describedby = hyper_ref("user_moderations");
+  const $oidc_clients_describedby = hyper_ref("user_oidc_clients");
 
   const hx_get_user_organizations_props = urls.users[
     ":id"
@@ -42,6 +43,12 @@ export async function UserPage({
     param: { id: user.id },
     query: { describedby: $moderations_describedby },
   });
+  const hx_get_user_oidc_clients_props = urls.users[":id"].oidc_clients.$hx_get(
+    {
+      param: { id: user.id },
+      query: { describedby: $oidc_clients_describedby },
+    },
+  );
 
   return (
     <main>
@@ -86,6 +93,21 @@ export async function UserPage({
         <div class="max-w-full overflow-x-auto">
           <div
             {...hx_get_user_moderations_props}
+            hx-target="this"
+            hx-trigger="load"
+            class={table()}
+          ></div>
+        </div>
+
+        <hr class="border-none py-3" />
+
+        <h1 id={$oidc_clients_describedby}>
+          Historique de connexion de {user.given_name}
+        </h1>
+
+        <div class="max-w-full overflow-x-auto">
+          <div
+            {...hx_get_user_oidc_clients_props}
             hx-target="this"
             hx-trigger="load"
             class={table()}


### PR DESCRIPTION
**Problem**

The users_oidc_clients table records every service connection a user makes, including which organization they authenticated through, but this data was invisible in the admin UI — making it impossible to audit a user's service usage history.

**Proposal**

Add an async-loaded connection history table on the user detail page (/users/:id/oidc_clients) that joins oidc_clients for the service label and organizations for the org label, loaded via hx-trigger="load" following the existing moderations/organizations pattern.

Seed oidc_clients (annuaire_entreprises, tchap, resana) and users_oidc_clients fixtures so the table is populated in dev.