### PR TITLE
✨ users: paginate OIDC connection history on user page

### DIFF
--- a/.release-it-changeset/1781186209-pagination-historique-connexion-oidc.md
+++ b/.release-it-changeset/1781186209-pagination-historique-connexion-oidc.md
@@ -1,0 +1,3 @@
+✨ Pagination de l'historique de connexion OIDC
+
+L'historique de connexion OIDC sur la page utilisateur est désormais paginé. Les connexions sont affichées par pages de 10, avec des boutons « Précédent » et « Suivant » pour naviguer dans la liste.

--- a/sources/web/src/routes.d.ts
+++ b/sources/web/src/routes.d.ts
@@ -1628,7 +1628,10 @@ declare const app: import("hono/hono-base").HonoBase<
                             };
                           } & {
                             query: {
-                              describedby: string;
+                              describedby: string | string[];
+                              page_ref: string | string[];
+                              page?: string | string[] | undefined;
+                              page_size?: string | string[] | undefined;
                             };
                           };
                           output: {};
@@ -1642,7 +1645,10 @@ declare const app: import("hono/hono-base").HonoBase<
                             };
                           } & {
                             query: {
-                              describedby: string;
+                              describedby: string | string[];
+                              page_ref: string | string[];
+                              page?: string | string[] | undefined;
+                              page_size?: string | string[] | undefined;
                             };
                           };
                           output: import("zod").ZodSafeParseError<{
@@ -1658,11 +1664,17 @@ declare const app: import("hono/hono-base").HonoBase<
                             };
                           } & {
                             query: {
-                              describedby: string;
+                              describedby: string | string[];
+                              page_ref: string | string[];
+                              page?: string | string[] | undefined;
+                              page_size?: string | string[] | undefined;
                             };
                           };
                           output: import("zod").ZodSafeParseError<{
+                            page: number;
+                            page_size: number;
                             describedby: string;
+                            page_ref: string;
                           }>;
                           outputFormat: "json";
                           status: 400;

--- a/sources/web/src/routes/users/:id/oidc_clients/Table.tsx
+++ b/sources/web/src/routes/users/:id/oidc_clients/Table.tsx
@@ -1,5 +1,8 @@
 //
 
+import { hx_include } from "#src/htmx";
+import type { Pagination } from "#src/schema";
+import { Foot } from "#src/ui/hx_table";
 import { table } from "#src/ui/table";
 import { LocalTime } from "#src/ui/time";
 import { urls } from "#src/urls";
@@ -7,15 +10,36 @@ import type { get_oidc_clients_by_user_id } from "./get_oidc_clients_by_user_id.
 
 //
 
-type ConnectionList = Awaited<ReturnType<typeof get_oidc_clients_by_user_id>>;
+type ConnectionsCollection = Awaited<
+  ReturnType<typeof get_oidc_clients_by_user_id>
+>;
+type Connection = ConnectionsCollection["connections"][number];
 
 export function Table({
-  connections,
+  connections_collection,
   describedby,
+  page_ref,
+  pagination,
+  user_id,
 }: {
-  connections: ConnectionList;
+  connections_collection: ConnectionsCollection;
   describedby: string;
+  page_ref: string;
+  pagination: Pagination;
+  user_id: number;
 }) {
+  const { connections, count } = connections_collection;
+
+  const hx_get_oidc_clients_query_props = {
+    ...urls.users[":id"].oidc_clients.$hx_get({
+      param: {
+        id: user_id,
+      },
+      query: { describedby, page_ref },
+    }),
+    "hx-include": hx_include([page_ref]),
+  };
+
   return (
     <table class={table()} aria-describedby={describedby}>
       <thead>
@@ -31,19 +55,21 @@ export function Table({
           <Row key={`${connection.id}`} connection={connection} />
         ))}
       </tbody>
+
+      <Foot
+        colspan={4}
+        count={count}
+        hx_query_props={hx_get_oidc_clients_query_props}
+        id={page_ref}
+        pagination={pagination}
+      />
     </table>
   );
 }
 
 //
 
-function Row({
-  connection,
-  key,
-}: {
-  connection: ConnectionList[number];
-  key?: string;
-}) {
+function Row({ connection, key }: { connection: Connection; key?: string }) {
   const org = connection.organization;
   const org_href = org
     ? urls.organizations[":id"].$url({ param: { id: org.id } }).pathname

--- a/sources/web/src/routes/users/:id/oidc_clients/context.ts
+++ b/sources/web/src/routes/users/:id/oidc_clients/context.ts
@@ -1,0 +1,12 @@
+//
+
+import { DescribedBySchema, EntitySchema, PaginationSchema } from "#src/schema";
+import { z } from "zod";
+
+//
+
+export const QuerySchema = PaginationSchema.merge(DescribedBySchema).extend({
+  page_ref: z.string(),
+});
+
+export const ParamSchema = EntitySchema;

--- a/sources/web/src/routes/users/:id/oidc_clients/get_oidc_clients_by_user_id.query.test.ts
+++ b/sources/web/src/routes/users/:id/oidc_clients/get_oidc_clients_by_user_id.query.test.ts
@@ -26,30 +26,33 @@ test("get adora's oidc connections", async () => {
   await create_unicorn_oidc_client(pg);
   await create_adora_pony_oidc_connection(pg, { sp_name: "🦄 sp" });
 
-  const connections = await get_oidc_clients_by_user_id(pg, user_id);
+  const result = await get_oidc_clients_by_user_id(pg, { user_id });
 
-  expect(connections).toMatchInlineSnapshot(`
-    [
-      {
-        "created_at": "2222-01-01 01:00:00+01",
-        "id": 1,
-        "oidc_client": {
-          "client_id": "🦄 client_id",
-          "client_name": "🦄 client_name",
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "connections": [
+        {
+          "created_at": "2222-01-01 01:00:00+01",
+          "id": 1,
+          "oidc_client": {
+            "client_id": "🦄 client_id",
+            "client_name": "🦄 client_name",
+          },
+          "organization": null,
+          "sp_name": "🦄 sp",
         },
-        "organization": null,
-        "sp_name": "🦄 sp",
-      },
-    ]
+      ],
+      "count": 1,
+    }
   `);
 });
 
 test("returns empty array when user has no connections", async () => {
   const user_id = await create_adora_pony_user(pg);
 
-  const connections = await get_oidc_clients_by_user_id(pg, user_id);
+  const result = await get_oidc_clients_by_user_id(pg, { user_id });
 
-  expect(connections).toEqual([]);
+  expect(result).toEqual({ connections: [], count: 0 });
 });
 
 test("returns connections ordered by created_at desc", async () => {
@@ -64,20 +67,57 @@ test("returns connections ordered by created_at desc", async () => {
     updated_at: "2024-06-01T00:00:00Z",
   });
 
-  const connections = await get_oidc_clients_by_user_id(pg, user_id);
+  const result = await get_oidc_clients_by_user_id(pg, { user_id });
 
-  expect(connections).toMatchInlineSnapshot(`
-    [
-      {
-        "created_at": "2024-06-01 01:00:00+01",
-        "id": 2,
-        "oidc_client": {
-          "client_id": "🦄 client_id",
-          "client_name": "🦄 client_name",
+  expect(result).toMatchInlineSnapshot(`
+    {
+      "connections": [
+        {
+          "created_at": "2024-06-01 01:00:00+01",
+          "id": 2,
+          "oidc_client": {
+            "client_id": "🦄 client_id",
+            "client_name": "🦄 client_name",
+          },
+          "organization": null,
+          "sp_name": null,
         },
-        "organization": null,
-        "sp_name": null,
-      },
+        {
+          "created_at": "2020-01-01 01:00:00+01",
+          "id": 1,
+          "oidc_client": {
+            "client_id": "🦄 client_id",
+            "client_name": "🦄 client_name",
+          },
+          "organization": null,
+          "sp_name": null,
+        },
+      ],
+      "count": 2,
+    }
+  `);
+});
+
+test("supports pagination", async () => {
+  const user_id = await create_adora_pony_user(pg);
+  await create_unicorn_oidc_client(pg);
+  await create_adora_pony_oidc_connection(pg, {
+    created_at: "2020-01-01T00:00:00Z",
+    updated_at: "2020-01-01T00:00:00Z",
+  });
+  await create_adora_pony_oidc_connection(pg, {
+    created_at: "2024-06-01T00:00:00Z",
+    updated_at: "2024-06-01T00:00:00Z",
+  });
+
+  const result = await get_oidc_clients_by_user_id(pg, {
+    user_id,
+    pagination: { page: 1, page_size: 1 },
+  });
+
+  expect(result.count).toBe(2);
+  expect(result.connections).toMatchInlineSnapshot(`
+    [
       {
         "created_at": "2020-01-01 01:00:00+01",
         "id": 1,

--- a/sources/web/src/routes/users/:id/oidc_clients/get_oidc_clients_by_user_id.query.ts
+++ b/sources/web/src/routes/users/:id/oidc_clients/get_oidc_clients_by_user_id.query.ts
@@ -1,30 +1,51 @@
 //
 
+import type { Pagination } from "#src/schema";
 import type { IdentiteProconnectPgDatabase } from "@~/identite-proconnect/database";
 import { schema } from "@~/identite-proconnect/database";
-import { desc, eq } from "drizzle-orm";
+import { desc, count as drizzle_count, eq } from "drizzle-orm";
 
 //
 
 export async function get_oidc_clients_by_user_id(
   pg: IdentiteProconnectPgDatabase,
-  user_id: number,
+  {
+    user_id,
+    pagination = { page: 0, page_size: 10 },
+  }: {
+    user_id: number;
+    pagination?: Pagination;
+  },
 ) {
-  return pg.query.users_oidc_clients.findMany({
-    columns: {
-      created_at: true,
-      id: true,
-      sp_name: true,
-    },
-    orderBy: desc(schema.users_oidc_clients.created_at),
-    where: eq(schema.users_oidc_clients.user_id, user_id),
-    with: {
-      oidc_client: {
-        columns: { client_id: true, client_name: true },
+  const { page, page_size: take } = pagination;
+
+  const where = eq(schema.users_oidc_clients.user_id, user_id);
+
+  return pg.transaction(async function connections_with_count(tx) {
+    const connections = await tx.query.users_oidc_clients.findMany({
+      columns: {
+        created_at: true,
+        id: true,
+        sp_name: true,
       },
-      organization: {
-        columns: { cached_libelle: true, id: true, siret: true },
+      limit: take,
+      offset: page * take,
+      orderBy: desc(schema.users_oidc_clients.created_at),
+      where,
+      with: {
+        oidc_client: {
+          columns: { client_id: true, client_name: true },
+        },
+        organization: {
+          columns: { cached_libelle: true, id: true, siret: true },
+        },
       },
-    },
+    });
+    const [{ value: count } = { value: NaN }] = await tx
+      .select({ value: drizzle_count() })
+      .from(schema.users_oidc_clients)
+      .where(where);
+
+    return { connections, count };
   });
 }

--- a/sources/web/src/routes/users/:id/oidc_clients/index.test.ts
+++ b/sources/web/src/routes/users/:id/oidc_clients/index.test.ts
@@ -37,7 +37,7 @@ test("GET /users/:id/oidc_clients renders connection history", async () => {
     .use(set_nonce("nonce"))
     .use(set_userinfo({ email: "test@example.com" }))
     .route("/:id/oidc_clients", app)
-    .request(`/${user_id}/oidc_clients?describedby=test`);
+    .request(`/${user_id}/oidc_clients?describedby=test&page_ref=test-ref`);
 
   const html = await response.text();
   expect(html).toContain("Service");
@@ -45,6 +45,27 @@ test("GET /users/:id/oidc_clients renders connection history", async () => {
   expect(html).toContain("🦄 client_name");
   expect(html).toContain("🦄 sp");
   expect(response.status).toBe(200);
+});
+
+test("GET /users/:id/oidc_clients handles pagination", async () => {
+  const user_id = await create_adora_pony_user(pg);
+  await create_unicorn_oidc_client(pg);
+  await create_adora_pony_oidc_connection(pg, { sp_name: "🦄 sp" });
+
+  const response = await new Hono()
+    .use(set_config({}))
+    .use(set_identite_pg(pg))
+    .use(set_nonce("nonce"))
+    .use(set_userinfo({ email: "test@example.com" }))
+    .route("/:id/oidc_clients", app)
+    .request(
+      `/${user_id}/oidc_clients?describedby=test&page_ref=test-ref&page=1&page_size=10`,
+    );
+
+  expect(response.status).toBe(200);
+  const html = await response.text();
+  expect(html).toContain("🦄 client_name");
+  expect(html).toContain("Suivant");
 });
 
 test("GET /users/:id/oidc_clients with no connections renders empty table", async () => {
@@ -56,7 +77,7 @@ test("GET /users/:id/oidc_clients with no connections renders empty table", asyn
     .use(set_nonce("nonce"))
     .use(set_userinfo({ email: "test@example.com" }))
     .route("/:id/oidc_clients", app)
-    .request(`/${user_id}/oidc_clients?describedby=test`);
+    .request(`/${user_id}/oidc_clients?describedby=test&page_ref=test-ref`);
 
   const html = await response.text();
   expect(html).toContain("Service");

--- a/sources/web/src/routes/users/:id/oidc_clients/index.tsx
+++ b/sources/web/src/routes/users/:id/oidc_clients/index.tsx
@@ -1,10 +1,12 @@
 //
 
 import type { AppContext } from "#src/middleware/context";
-import { DescribedBySchema, EntitySchema } from "#src/schema";
+import { PaginationSchema } from "#src/schema";
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { jsxRenderer } from "hono/jsx-renderer";
+import { match } from "ts-pattern";
+import { ParamSchema, QuerySchema } from "./context";
 import { get_oidc_clients_by_user_id } from "./get_oidc_clients_by_user_id.query";
 import { Table } from "./Table";
 
@@ -14,18 +16,32 @@ export default new Hono<AppContext>()
   .use("/", jsxRenderer())
   .get(
     "/",
-    zValidator("param", EntitySchema),
-    zValidator("query", DescribedBySchema),
+    zValidator("param", ParamSchema),
+    zValidator("query", QuerySchema),
     async function GET({ render, req, var: { identite_pg } }) {
       const { id: user_id } = req.valid("param");
-      const { describedby } = req.valid("query");
-      const connections = await get_oidc_clients_by_user_id(
+      const { describedby, page_ref } = req.valid("query");
+
+      const pagination = match(PaginationSchema.safeParse(req.query()))
+        .with({ success: true }, ({ data }) => data)
+        .otherwise(() => PaginationSchema.parse({}));
+
+      const connections_collection = await get_oidc_clients_by_user_id(
         identite_pg,
-        user_id,
+        {
+          user_id,
+          pagination: { ...pagination, page: pagination.page - 1 },
+        },
       );
 
       return render(
-        <Table connections={connections} describedby={describedby} />,
+        <Table
+          connections_collection={connections_collection}
+          describedby={describedby}
+          page_ref={page_ref}
+          pagination={pagination}
+          user_id={user_id}
+        />,
       );
     },
   );

--- a/sources/web/src/routes/users/:id/page.tsx
+++ b/sources/web/src/routes/users/:id/page.tsx
@@ -46,7 +46,7 @@ export async function UserPage({
   const hx_get_user_oidc_clients_props = urls.users[":id"].oidc_clients.$hx_get(
     {
       param: { id: user.id },
-      query: { describedby: $oidc_clients_describedby },
+      query: { describedby: $oidc_clients_describedby, page_ref: hyper_ref() },
     },
   );
 


### PR DESCRIPTION
**Problem**

The OIDC connection history table on the user page rendered every connection at once. For active users this list grows unbounded, making the page heavy and the history hard to browse.

**Proposal**

Paginate the /users/:id/oidc_clients route like the user organizations table: the query now returns { connections, count } with limit/offset, and the table renders the shared <Foot> pager (10 rows per page) wired through htmx page_ref includes.