### PR TITLE
✨ hide comments section if no comment

### DIFF
--- a/.release-it-changeset/1782313721-hide-comment-section-when-empt.md
+++ b/.release-it-changeset/1782313721-hide-comment-section-when-empt.md
@@ -1,0 +1,1 @@
+✨ Affichage de la section "Commentaires" uniquement s'il y a au moins un commentaire pour la modération concernée

--- a/sources/web/src/ui/moderations/Header/Header.tsx
+++ b/sources/web/src/ui/moderations/Header/Header.tsx
@@ -231,6 +231,9 @@ function LastComment() {
 function Comments() {
   const { comment } = useContext(context).moderation;
   const parsed_comment = parse_comment(comment);
+  if (parsed_comment.length === 0) {
+    return <em>Aucun commentaire</em>;
+  }
   const last_index = parsed_comment.length - 1;
   return (
     <details>

--- a/sources/web/src/ui/moderations/Header/__snapshots__/Header.test.tsx.snap
+++ b/sources/web/src/ui/moderations/Header/__snapshots__/Header.test.tsx.snap
@@ -46,10 +46,7 @@ exports[`render header section 1`] = `
     </div>
   </div>
   <hr class="border-none py-3" />
-  <details>
-    <summary>Commentaires</summary>
-    <ul class="ml-4"></ul>
-  </details>
+  <em>Aucun commentaire</em>
   <hr class="border-none py-3" />
   <div
     hx-get="/moderations/42/duplicate_warning?organization_id=43&amp;user_id=44"


### PR DESCRIPTION
**Problem**
The comments section remains clickable even when it is empty, forcing agents to open it just to verify that no comments exist.

**Proposal**
Display an "No comments" message when the comments list is empty, making the absence of comments immediately visible.