### PR TITLE
🛂 restrict DB writes to admin and moderator roles

### DIFF
--- a/.release-it-changeset/1782395397-hide-edit-ui-visitors.md
+++ b/.release-it-changeset/1782395397-hide-edit-ui-visitors.md
@@ -1,0 +1,3 @@
+🔒 Restriction de l'interface d'édition aux visiteurs
+
+Les visiteurs ne peuvent plus accéder aux actions d'édition ni effectuer de modifications en base de données. Les droits d'écriture sont désormais réservés aux rôles administrateur et modérateur.

--- a/e2e/features/organizations/member_actions.feature
+++ b/e2e/features/organizations/member_actions.feature
@@ -4,7 +4,7 @@ Fonctionnalité: Actions sur les membres d'une organisation
   Contexte:
     Soit une base de données nourrie au grain
     Quand je navigue sur la page
-    Et je me connecte en tant que "jeanbon@yopmail.com"
+    Et je me connecte en tant que "moderateur@beta.gouv.fr"
     Et je clique sur "Organisations"
     Alors je suis redirigé sur "/organizations"
     Quand je clique sur le lien nommé "Organisation Direction interministerielle du numerique (DINUM) (13002526500013)"

--- a/e2e/features/security/visitor_read_only.feature
+++ b/e2e/features/security/visitor_read_only.feature
@@ -1,0 +1,30 @@
+# language: fr
+Fonctionnalité: Un visiteur ne peut pas modifier les données
+
+  Contexte:
+    Soit une base de données nourrie au grain
+    Quand je navigue sur la page
+    Et je me connecte en tant que "jeanbon@yopmail.com"
+
+  Scénario: Le visiteur ne voit pas les actions d'édition des templates de réponse
+    Etant donné que je suis sur la page "/response-templates"
+    Alors je vois "Templates de réponse"
+    Mais je ne vois pas "Nouveau template"
+    Et je ne vois pas "Éditer"
+
+  Scénario: Le visiteur ne voit pas le menu d'actions sur les membres d'une organisation
+    Quand je clique sur "Organisations"
+    Alors je suis redirigé sur "/organizations"
+    Quand je clique sur le lien nommé "Organisation Direction interministerielle du numerique (DINUM) (13002526500013)"
+    Quand je clique sur "1 membre"
+    Quand je vais à l'intérieur de la rangée nommée "Membre Raphael Dubigny (rdubigny@beta.gouv.fr)"
+    Alors je vois "Raphael"
+    Mais je ne vois pas "Menu"
+    Et je ne vois pas "retirer de l'orga"
+    Et je réinitialise le contexte
+
+  Scénario: Le visiteur ne voit pas la barre d'outils de modération
+    Etant donné que je suis sur la page "/moderations"
+    Quand je clique sur le lien nommé "Modération a traiter de Jean Bon pour 13002526500013"
+    Alors je ne vois pas "✅ Accepter"
+    Et je ne vois pas "❌ Refuser"

--- a/sources/web/src/middleware/auth/authorized.tsx
+++ b/sources/web/src/middleware/auth/authorized.tsx
@@ -1,7 +1,12 @@
 //
 
 import { is_htmx_request, type HtmxHeader } from "#src/htmx";
-import { roles, schema, type HyyyperPgDatabase, type Roles } from "@~/hyyyperbase";
+import {
+  roles,
+  schema,
+  type HyyyperPgDatabase,
+  type Roles,
+} from "@~/hyyyperbase";
 import { and, eq, isNull } from "drizzle-orm";
 import type { Env } from "hono";
 import { createMiddleware } from "hono/factory";
@@ -75,10 +80,7 @@ export function editor_guard() {
   return createMiddleware<HyyyperUserContext>(
     async function editor_guard_middleware(c, next) {
       const { role } = c.var.hyyyper_user;
-      if (
-        role !== roles.enum.admin &&
-        role !== roles.enum.moderator
-      ) {
+      if (role !== roles.enum.admin && role !== roles.enum.moderator) {
         if (is_htmx_request(c.req.raw)) {
           return c.text("Forbidden", 403, {
             "HX-Location": "/",

--- a/sources/web/src/middleware/auth/authorized.tsx
+++ b/sources/web/src/middleware/auth/authorized.tsx
@@ -1,7 +1,7 @@
 //
 
 import { is_htmx_request, type HtmxHeader } from "#src/htmx";
-import { schema, type HyyyperPgDatabase, type Roles } from "@~/hyyyperbase";
+import { roles, schema, type HyyyperPgDatabase, type Roles } from "@~/hyyyperbase";
 import { and, eq, isNull } from "drizzle-orm";
 import type { Env } from "hono";
 import { createMiddleware } from "hono/factory";
@@ -66,6 +66,26 @@ export function authorized() {
 
       c.set("hyyyper_user", db_user);
 
+      return next();
+    },
+  );
+}
+
+export function editor_guard() {
+  return createMiddleware<HyyyperUserContext>(
+    async function editor_guard_middleware(c, next) {
+      const { role } = c.var.hyyyper_user;
+      if (
+        role !== roles.enum.admin &&
+        role !== roles.enum.moderator
+      ) {
+        if (is_htmx_request(c.req.raw)) {
+          return c.text("Forbidden", 403, {
+            "HX-Location": "/",
+          } as HtmxHeader);
+        }
+        return c.redirect("/");
+      }
       return next();
     },
   );

--- a/sources/web/src/middleware/auth/index.ts
+++ b/sources/web/src/middleware/auth/index.ts
@@ -3,6 +3,7 @@
 export type { AgentConnectUserInfo } from "./AgentConnectUserInfo";
 export {
   authorized,
+  editor_guard,
   type HyyyperUser,
   type HyyyperUserContext,
 } from "./authorized";

--- a/sources/web/src/routes/moderations/:id/index.test.ts
+++ b/sources/web/src/routes/moderations/:id/index.test.ts
@@ -9,7 +9,10 @@ import {
   hyyyper_pglite,
   empty_database as hyyyperbase_empty_database,
 } from "@~/hyyyperbase/testing";
-import { insert_moderateur } from "@~/hyyyperbase/testing/users";
+import {
+  insert_jeanbon,
+  insert_moderateur,
+} from "@~/hyyyperbase/testing/users";
 import {
   create_adora_pony_moderation,
   create_adora_pony_user,
@@ -79,6 +82,32 @@ test("GET /moderations/:id returns 404 for non-existent moderation", async () =>
   expect(response.status).toBe(404);
   const html = await response.text();
   expect(html).toContain("Modération <em>999999</em> non trouvée");
+});
+
+test("GET /moderations/:id hides action toolbar for visitors", async () => {
+  const visitor = await insert_jeanbon(hyyyper_pglite);
+  const user_id = await create_adora_pony_user(pg);
+  const organization_id = await create_unicorn_organization(pg);
+  const moderation_id = await create_adora_pony_moderation(pg, {
+    type: "non_verified_domain",
+    status: "pending",
+  });
+
+  const response = await new Hono()
+    .use(set_config({ HTTP_CLIENT_TIMEOUT: 5000 }))
+    .use(set_hyyyper_pg(hyyyper_pglite))
+    .use(set_identite_pg(pg))
+    .use(set_nonce("nonce"))
+    .use(set_userinfo({ email: visitor.email, sub: visitor.sub! }))
+    .use(authorized())
+    .route("/:id", app)
+    .request(`/${moderation_id}`);
+
+  expect(response.status).toBe(200);
+  const html = await response.text();
+
+  expect(html).not.toContain("✅ Accepter");
+  expect(html).not.toContain("❌ Refuser");
 });
 
 //

--- a/sources/web/src/routes/moderations/:id/index.tsx
+++ b/sources/web/src/routes/moderations/:id/index.tsx
@@ -14,6 +14,7 @@ import {
 } from "#src/queries/organizations";
 import { EntitySchema, z_email_domain } from "#src/schema";
 import { zValidator } from "@hono/zod-validator";
+import { roles } from "@~/hyyyperbase";
 import { to } from "await-to-js";
 import { Hono } from "hono";
 import { jsxRenderer } from "hono/jsx-renderer";
@@ -88,7 +89,7 @@ export default new Hono<AppContext>()
 
         const response_templates = await get_response_templates(hyyyper_pg, "");
 
-        const is_editor = hyyyper_user.role !== "visitor";
+        const is_editor = hyyyper_user.role !== roles.enum.visitor;
         const page_data = {
           banaticUrl,
           domain,

--- a/sources/web/src/routes/moderations/:id/index.tsx
+++ b/sources/web/src/routes/moderations/:id/index.tsx
@@ -4,6 +4,7 @@ import { NotFoundError } from "#src/errors";
 import { Main_Layout } from "#src/layouts";
 import { moderation_type_to_title } from "#src/lib/moderations";
 import { GetBanaticUrl } from "#src/lib/organizations/usecase";
+import { editor_guard } from "#src/middleware/auth";
 import type { AppContext } from "#src/middleware/context";
 import { GetModerationWithDetails } from "#src/queries/moderations";
 import {
@@ -117,6 +118,7 @@ export default new Hono<AppContext>()
   )
   .route("/email", moderation_email_router)
   .route("/duplicate_warning", duplicate_warning_router)
+  .use(editor_guard())
   .route("/validate", moderation_validate_router)
   .route("/rejected", moderation_rejected_router)
   .route("/processed", moderation_processed_router)

--- a/sources/web/src/routes/moderations/:id/index.tsx
+++ b/sources/web/src/routes/moderations/:id/index.tsx
@@ -41,7 +41,7 @@ export default new Hono<AppContext>()
       set,
       status,
       env: config,
-      var: { identite_pg, hyyyper_pg },
+      var: { identite_pg, hyyyper_pg, hyyyper_user },
     }) {
       const { id } = req.valid("param");
 
@@ -88,6 +88,7 @@ export default new Hono<AppContext>()
 
         const response_templates = await get_response_templates(hyyyper_pg, "");
 
+        const is_editor = hyyyper_user.role !== "visitor";
         const page_data = {
           banaticUrl,
           domain,
@@ -99,6 +100,7 @@ export default new Hono<AppContext>()
           query_organization_members_count: get_organization_members_count(
             moderation.organization_id,
           ),
+          is_editor,
         };
 
         set(

--- a/sources/web/src/routes/moderations/:id/page.tsx
+++ b/sources/web/src/routes/moderations/:id/page.tsx
@@ -42,6 +42,7 @@ type PageData = {
   query_organization_members_count: Promise<number>;
   response_templates: ResponseTemplateDto[];
   identite_pg: IdentiteProconnectPgDatabase;
+  is_editor: boolean;
 };
 
 const PageContext = createContext<PageData>({} as PageData);
@@ -63,6 +64,7 @@ async function ModerationPageContent() {
     query_domain_count,
     query_organization_members_count,
     response_templates,
+    is_editor,
   } = useContext(PageContext)!;
 
   const moderation_id = `moderation-${moderation.id}`;
@@ -154,6 +156,7 @@ async function ModerationPageContent() {
         <Actions
           moderation={moderation}
           response_templates={response_templates}
+          is_editor={is_editor}
         />
 
         <hr class="border-none py-3" />

--- a/sources/web/src/routes/organizations/:id/members/:user_id/index.test.ts
+++ b/sources/web/src/routes/organizations/:id/members/:user_id/index.test.ts
@@ -1,9 +1,15 @@
 //
 
-import { set_userinfo } from "#src/middleware/auth";
+import { authorized, set_userinfo } from "#src/middleware/auth";
 import { set_config } from "#src/middleware/config";
+import { set_hyyyper_pg } from "#src/middleware/hyyyperbase";
 import { set_identite_pg } from "#src/middleware/identite-pg";
 import { set_nonce } from "#src/middleware/nonce";
+import {
+  hyyyper_pglite,
+  empty_database as hyyyperbase_empty_database,
+} from "@~/hyyyperbase/testing";
+import { insert_moderateur } from "@~/hyyyperbase/testing/users";
 import { schema } from "@~/identite-proconnect/database";
 import {
   create_adora_pony_user,
@@ -23,9 +29,22 @@ import app from "./index";
 
 beforeAll(migrate);
 beforeEach(empty_database);
+beforeEach(hyyyperbase_empty_database);
 setSystemTime(new Date("2222-02-22 22:22:22+22"));
 
 //
+
+async function make_app() {
+  const moderator = await insert_moderateur(hyyyper_pglite);
+  return new Hono()
+    .use(set_config({}))
+    .use(set_hyyyper_pg(hyyyper_pglite))
+    .use(set_identite_pg(pg))
+    .use(set_nonce("nonce"))
+    .use(set_userinfo({ email: moderator.email, sub: moderator.sub! }))
+    .use(authorized())
+    .route("/:id/members/:user_id", app);
+}
 
 test("PATCH /organizations/:id/members/:user_id updates user organization membership", async () => {
   const organization_id = await create_unicorn_organization(pg);
@@ -61,20 +80,18 @@ test("PATCH /organizations/:id/members/:user_id updates user organization member
     `);
   }
 
-  const response = await new Hono()
-    .use(set_config({}))
-    .use(set_identite_pg(pg))
-    .use(set_nonce("nonce"))
-    .use(set_userinfo({ email: "test@example.com" }))
-    .route("/:id/members/:user_id", app)
-    .request(`/${organization_id}/members/${user_id}`, {
+  const testing_app = await make_app();
+  const response = await testing_app.request(
+    `/${organization_id}/members/${user_id}`,
+    {
       method: "PATCH",
       body: new URLSearchParams({
         is_external: "true",
         verification_type: VerificationTypeSchema.enum.domain,
       }),
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    });
+    },
+  );
 
   expect(response.status).toBe(200);
   expect(response.headers.get("HX-Trigger")).toBe("MEMBERS_UPDATED");
@@ -138,19 +155,17 @@ test("PATCH /organizations/:id/members/:user_id clears verification with domain_
     `);
   }
 
-  const response = await new Hono()
-    .use(set_config({}))
-    .use(set_identite_pg(pg))
-    .use(set_nonce("nonce"))
-    .use(set_userinfo({ email: "test@example.com" }))
-    .route("/:id/members/:user_id", app)
-    .request(`/${organization_id}/members/${user_id}`, {
+  const testing_app = await make_app();
+  const response = await testing_app.request(
+    `/${organization_id}/members/${user_id}`,
+    {
       method: "PATCH",
       body: new URLSearchParams({
         verification_type: VerificationTypeSchema.enum.domain_not_verified_yet,
       }),
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
-    });
+    },
+  );
 
   expect(response.status).toBe(200);
   expect(response.headers.get("HX-Trigger")).toBe("MEMBERS_UPDATED");
@@ -197,15 +212,13 @@ test("DELETE /organizations/:id/members/:user_id removes user from organization"
     expect(result).toHaveLength(1);
   }
 
-  const response = await new Hono()
-    .use(set_config({}))
-    .use(set_identite_pg(pg))
-    .use(set_nonce("nonce"))
-    .use(set_userinfo({ email: "test@example.com" }))
-    .route("/:id/members/:user_id", app)
-    .request(`/${organization_id}/members/${user_id}`, {
+  const testing_app = await make_app();
+  const response = await testing_app.request(
+    `/${organization_id}/members/${user_id}`,
+    {
       method: "DELETE",
-    });
+    },
+  );
 
   expect(response.status).toBe(200);
   expect(response.headers.get("HX-Trigger")).toBe("MEMBERS_UPDATED");

--- a/sources/web/src/routes/organizations/:id/members/:user_id/index.ts
+++ b/sources/web/src/routes/organizations/:id/members/:user_id/index.ts
@@ -2,6 +2,7 @@
 
 import type { HtmxHeader } from "#src/htmx";
 import { ORGANISATION_EVENTS } from "#src/lib/organizations";
+import { editor_guard } from "#src/middleware/auth";
 import type { AppContext } from "#src/middleware/context";
 import { RemoveUserFromOrganization } from "#src/queries/moderations";
 import { EntitySchema } from "#src/schema";
@@ -17,7 +18,7 @@ const params_schema = EntitySchema.extend({
   user_id: z.string().pipe(z.coerce.number()),
 });
 export default new Hono<AppContext>()
-  //
+  .use(editor_guard())
   .patch(
     "/",
     zValidator("param", params_schema),

--- a/sources/web/src/routes/organizations/:id/members/Table.tsx
+++ b/sources/web/src/routes/organizations/:id/members/Table.tsx
@@ -24,12 +24,14 @@ export async function Table({
   query_members_collection,
   describedby,
   page_ref,
+  is_editor = true,
 }: {
   organization_id: number;
   pagination: Pagination;
   query_members_collection: QueryResult;
   describedby: string;
   page_ref: string;
+  is_editor?: boolean;
 }) {
   const { users, count } = query_members_collection;
 
@@ -60,7 +62,7 @@ export async function Table({
 
       <tbody>
         {users.map((user) => (
-          <MemberContext.Provider value={{ user, organization_id }}>
+          <MemberContext.Provider value={{ user, organization_id, is_editor }}>
             <Row />
           </MemberContext.Provider>
         ))}
@@ -78,7 +80,7 @@ export async function Table({
 }
 
 function Row({ variants }: { variants?: VariantProps<typeof row> }) {
-  const { user } = useContext(MemberContext);
+  const { user, is_editor } = useContext(MemberContext);
 
   return (
     <tr
@@ -113,7 +115,7 @@ function Row({ variants }: { variants?: VariantProps<typeof row> }) {
         )}
       </td>
       <td class="space-x-2 text-end">
-        <RowActions />
+        {is_editor && <RowActions />}
       </td>
     </tr>
   );

--- a/sources/web/src/routes/organizations/:id/members/Table.tsx
+++ b/sources/web/src/routes/organizations/:id/members/Table.tsx
@@ -114,9 +114,7 @@ function Row({ variants }: { variants?: VariantProps<typeof row> }) {
           </div>
         )}
       </td>
-      <td class="space-x-2 text-end">
-        {is_editor && <RowActions />}
-      </td>
+      <td class="space-x-2 text-end">{is_editor && <RowActions />}</td>
     </tr>
   );
 }

--- a/sources/web/src/routes/organizations/:id/members/context.ts
+++ b/sources/web/src/routes/organizations/:id/members/context.ts
@@ -12,4 +12,5 @@ type User = Awaited<
 export const MemberContext = createContext({
   user: {} as User,
   organization_id: 0,
+  is_editor: true,
 });

--- a/sources/web/src/routes/organizations/:id/members/index.test.ts
+++ b/sources/web/src/routes/organizations/:id/members/index.test.ts
@@ -1,9 +1,18 @@
 //
 
-import { set_userinfo } from "#src/middleware/auth";
+import { authorized, set_userinfo } from "#src/middleware/auth";
 import { set_config } from "#src/middleware/config";
+import { set_hyyyper_pg } from "#src/middleware/hyyyperbase";
 import { set_identite_pg } from "#src/middleware/identite-pg";
 import { set_nonce } from "#src/middleware/nonce";
+import {
+  hyyyper_pglite,
+  empty_database as hyyyperbase_empty_database,
+} from "@~/hyyyperbase/testing";
+import {
+  insert_jeanbon,
+  insert_moderateur,
+} from "@~/hyyyperbase/testing/users";
 import { schema } from "@~/identite-proconnect/database";
 import {
   create_adora_pony_user,
@@ -22,14 +31,15 @@ import app from "./index";
 
 beforeAll(migrate);
 beforeEach(empty_database);
+beforeEach(hyyyperbase_empty_database);
 
 //
 
 test("GET /organizations/:id/members returns members for organization", async () => {
+  const moderator = await insert_moderateur(hyyyper_pglite);
   const organization_id = await create_unicorn_organization(pg);
   const user_id = await create_adora_pony_user(pg);
 
-  // Add user to organization
   await pg.insert(schema.users_organizations).values({
     user_id,
     organization_id,
@@ -39,9 +49,11 @@ test("GET /organizations/:id/members returns members for organization", async ()
 
   const response = await new Hono()
     .use(set_config({}))
+    .use(set_hyyyper_pg(hyyyper_pglite))
     .use(set_identite_pg(pg))
     .use(set_nonce("nonce"))
-    .use(set_userinfo({ email: "test@example.com" }))
+    .use(set_userinfo({ email: moderator.email, sub: moderator.sub! }))
+    .use(authorized())
     .route("/:id/members", app)
     .request(
       `/${organization_id}/members?describedby=test-id&page_ref=members-table`,
@@ -51,15 +63,44 @@ test("GET /organizations/:id/members returns members for organization", async ()
 
   const html = await response.text();
 
-  // Check for table structure
   expect(html).toContain("Prénom");
   expect(html).toContain("Nom");
   expect(html).toContain("Email");
   expect(html).toContain("Fonction");
 
-  // Verify member data is displayed
   expect(html).toContain("Adora");
   expect(html).toContain("Pony");
   expect(html).toContain("adora.pony@unicorn.xyz");
   expect(html).toContain("domain");
+});
+
+test("GET /organizations/:id/members hides member actions for visitors", async () => {
+  const visitor = await insert_jeanbon(hyyyper_pglite);
+  const organization_id = await create_unicorn_organization(pg);
+  const user_id = await create_adora_pony_user(pg);
+
+  await pg.insert(schema.users_organizations).values({
+    user_id,
+    organization_id,
+    is_external: false,
+    verification_type: "domain",
+  });
+
+  const response = await new Hono()
+    .use(set_config({}))
+    .use(set_hyyyper_pg(hyyyper_pglite))
+    .use(set_identite_pg(pg))
+    .use(set_nonce("nonce"))
+    .use(set_userinfo({ email: visitor.email, sub: visitor.sub! }))
+    .use(authorized())
+    .route("/:id/members", app)
+    .request(
+      `/${organization_id}/members?describedby=test-id&page_ref=members-table`,
+    );
+
+  expect(response.status).toBe(200);
+
+  const html = await response.text();
+
+  expect(html).not.toContain("retirer de l'orga");
 });

--- a/sources/web/src/routes/organizations/:id/members/index.tsx
+++ b/sources/web/src/routes/organizations/:id/members/index.tsx
@@ -3,6 +3,7 @@
 import type { AppContext } from "#src/middleware/context";
 import { DescribedBySchema, EntitySchema, PaginationSchema } from "#src/schema";
 import { zValidator } from "@hono/zod-validator";
+import { roles } from "@~/hyyyperbase";
 import { Hono } from "hono";
 import { jsxRenderer } from "hono/jsx-renderer";
 import { match } from "ts-pattern";
@@ -43,7 +44,7 @@ export default new Hono<AppContext>()
         },
       );
 
-      const is_editor = hyyyper_user.role !== "visitor";
+      const is_editor = hyyyper_user.role !== roles.enum.visitor;
       return render(
         <Table
           organization_id={organization_id}

--- a/sources/web/src/routes/organizations/:id/members/index.tsx
+++ b/sources/web/src/routes/organizations/:id/members/index.tsx
@@ -28,7 +28,7 @@ export default new Hono<AppContext>()
         page_ref: z.string(),
       }),
     ),
-    async function GET({ render, req, var: { identite_pg } }) {
+    async function GET({ render, req, var: { identite_pg, hyyyper_user } }) {
       const { id: organization_id } = req.valid("param");
       const { describedby, page_ref } = req.valid("query");
       const pagination = match(PaginationSchema.safeParse(req.query()))
@@ -43,6 +43,7 @@ export default new Hono<AppContext>()
         },
       );
 
+      const is_editor = hyyyper_user.role !== "visitor";
       return render(
         <Table
           organization_id={organization_id}
@@ -50,6 +51,7 @@ export default new Hono<AppContext>()
           query_members_collection={query_members_collection}
           describedby={describedby}
           page_ref={page_ref}
+          is_editor={is_editor}
         />,
       );
     },

--- a/sources/web/src/routes/response-templates/detail.page.tsx
+++ b/sources/web/src/routes/response-templates/detail.page.tsx
@@ -61,24 +61,42 @@ export default function DetailPage({
       </div>
 
       {is_editor && (
-        <form
-          {...(is_new
-            ? { method: "post", action: form_action }
-            : { "hx-patch": form_action })}
-        >
-          <TemplateEditorIsland
-            initialTemplate={template?.content ?? ""}
-            initialLabel={template?.label ?? ""}
-            initialEndUserReason={template?.end_user_reason ?? ""}
-            initialAllowEditing={template?.allow_editing ?? false}
-          />
-          <div class="mt-6 flex justify-end">
-            <button type="submit" class={button()}>
-              Enregistrer
-            </button>
-          </div>
-        </form>
+        <TemplateForm
+          template={template}
+          form_action={form_action}
+          is_new={is_new}
+        />
       )}
     </main>
+  );
+}
+
+function TemplateForm({
+  template,
+  form_action,
+  is_new,
+}: {
+  template?: TemplateMetadata;
+  form_action: string;
+  is_new: boolean;
+}) {
+  return (
+    <form
+      {...(is_new
+        ? { method: "post", action: form_action }
+        : { "hx-patch": form_action })}
+    >
+      <TemplateEditorIsland
+        initialTemplate={template?.content ?? ""}
+        initialLabel={template?.label ?? ""}
+        initialEndUserReason={template?.end_user_reason ?? ""}
+        initialAllowEditing={template?.allow_editing ?? false}
+      />
+      <div class="mt-6 flex justify-end">
+        <button type="submit" class={button()}>
+          Enregistrer
+        </button>
+      </div>
+    </form>
   );
 }

--- a/sources/web/src/routes/response-templates/detail.page.tsx
+++ b/sources/web/src/routes/response-templates/detail.page.tsx
@@ -16,9 +16,11 @@ type TemplateMetadata = NonNullable<
 export default function DetailPage({
   template,
   status,
+  is_editor = false,
 }: {
   template?: TemplateMetadata;
   status?: "created";
+  is_editor?: boolean;
 }) {
   const is_new = !template;
   const form_action = is_new
@@ -47,7 +49,7 @@ export default function DetailPage({
           <Svg name="arrow-go-back" />
           Retour à la liste
         </a>
-        {!is_new && (
+        {!is_new && is_editor && (
           <button
             class={button({ intent: "danger", size: "sm" })}
             hx-delete={form_action}
@@ -58,23 +60,25 @@ export default function DetailPage({
         )}
       </div>
 
-      <form
-        {...(is_new
-          ? { method: "post", action: form_action }
-          : { "hx-patch": form_action })}
-      >
-        <TemplateEditorIsland
-          initialTemplate={template?.content ?? ""}
-          initialLabel={template?.label ?? ""}
-          initialEndUserReason={template?.end_user_reason ?? ""}
-          initialAllowEditing={template?.allow_editing ?? false}
-        />
-        <div class="mt-6 flex justify-end">
-          <button type="submit" class={button()}>
-            Enregistrer
-          </button>
-        </div>
-      </form>
+      {is_editor && (
+        <form
+          {...(is_new
+            ? { method: "post", action: form_action }
+            : { "hx-patch": form_action })}
+        >
+          <TemplateEditorIsland
+            initialTemplate={template?.content ?? ""}
+            initialLabel={template?.label ?? ""}
+            initialEndUserReason={template?.end_user_reason ?? ""}
+            initialAllowEditing={template?.allow_editing ?? false}
+          />
+          <div class="mt-6 flex justify-end">
+            <button type="submit" class={button()}>
+              Enregistrer
+            </button>
+          </div>
+        </form>
+      )}
     </main>
   );
 }

--- a/sources/web/src/routes/response-templates/index.test.ts
+++ b/sources/web/src/routes/response-templates/index.test.ts
@@ -1,12 +1,15 @@
 //
 
-import { set_userinfo } from "#src/middleware/auth";
+import { authorized, set_userinfo } from "#src/middleware/auth";
 import { set_config } from "#src/middleware/config";
 import { set_hyyyper_pg } from "#src/middleware/hyyyperbase";
 import { set_nonce } from "#src/middleware/nonce";
 import { empty_database, hyyyper_pglite } from "@~/hyyyperbase/testing";
 import { insert_central_administration_response } from "@~/hyyyperbase/testing/response_templates";
-import { insert_moderateur } from "@~/hyyyperbase/testing/users";
+import {
+  insert_jeanbon,
+  insert_moderateur,
+} from "@~/hyyyperbase/testing/users";
 import { beforeEach, expect, test } from "bun:test";
 import { Hono } from "hono";
 import { html as html_encode } from "hono/html";
@@ -23,6 +26,7 @@ async function make_app() {
     .use(set_nonce("nonce"))
     .use(set_hyyyper_pg(hyyyper_pglite))
     .use(set_userinfo({ email: moderator.email, sub: moderator.sub! }))
+    .use(authorized())
     .route("/", app);
 }
 
@@ -78,4 +82,25 @@ test("DELETE /response-templates/:id deletes template and redirects to list", as
   const remaining = await testing_app.request("/");
   const html = await remaining.text();
   expect(html).not.toContain(html_encode`${template.label}`.toString());
+});
+
+test("GET /response-templates hides edit controls for visitors", async () => {
+  const visitor = await insert_jeanbon(hyyyper_pglite);
+  await insert_central_administration_response(hyyyper_pglite);
+
+  const testing_app = new Hono()
+    .use(set_config({ ALLOWED_USERS: visitor.email }))
+    .use(set_nonce("nonce"))
+    .use(set_hyyyper_pg(hyyyper_pglite))
+    .use(set_userinfo({ email: visitor.email, sub: visitor.sub! }))
+    .use(authorized())
+    .route("/", app);
+
+  const response = await testing_app.request("/");
+
+  expect(response.status).toBe(200);
+  const html = await response.text();
+  expect(html).toContain("Templates de réponse");
+  expect(html).not.toContain("Nouveau template");
+  expect(html).not.toContain("Éditer");
 });

--- a/sources/web/src/routes/response-templates/index.tsx
+++ b/sources/web/src/routes/response-templates/index.tsx
@@ -4,7 +4,7 @@ import { Main_Layout } from "#src/layouts";
 import { authorized, editor_guard } from "#src/middleware/auth";
 import type { AppContext } from "#src/middleware/context";
 import { zValidator } from "@hono/zod-validator";
-import { schema } from "@~/hyyyperbase";
+import { roles, schema } from "@~/hyyyperbase";
 import { eq } from "drizzle-orm";
 import { Hono } from "hono";
 import { jsxRenderer } from "hono/jsx-renderer";
@@ -33,13 +33,22 @@ export default new Hono<AppContext>()
   .get(
     "/",
     jsxRenderer(Main_Layout),
-    async function GET({ render, set, req, var: { hyyyper_pg, hyyyper_user } }) {
+    async function GET({
+      render,
+      set,
+      req,
+      var: { hyyyper_pg, hyyyper_user },
+    }) {
       set("page_title", "Templates de réponse");
       const searchQuery = req.query("q") ?? "";
       const templates = await get_response_templates(hyyyper_pg, searchQuery);
-      const is_editor = hyyyper_user.role !== "visitor";
+      const is_editor = hyyyper_user.role !== roles.enum.visitor;
       return render(
-        <Page templates={templates} searchQuery={searchQuery} is_editor={is_editor} />,
+        <Page
+          templates={templates}
+          searchQuery={searchQuery}
+          is_editor={is_editor}
+        />,
       );
     },
   )
@@ -48,14 +57,20 @@ export default new Hono<AppContext>()
     jsxRenderer(Main_Layout),
     function GET({ render, set, var: { hyyyper_user } }) {
       set("page_title", "Nouveau template");
-      const is_editor = hyyyper_user.role !== "visitor";
+      const is_editor = hyyyper_user.role !== roles.enum.visitor;
       return render(<DetailPage is_editor={is_editor} />);
     },
   )
   .get(
     "/:id",
     jsxRenderer(Main_Layout),
-    async function GET({ render, set, req, var: { hyyyper_pg, hyyyper_user }, notFound }) {
+    async function GET({
+      render,
+      set,
+      req,
+      var: { hyyyper_pg, hyyyper_user },
+      notFound,
+    }) {
       const id = parseInt(req.param("id"), 10);
       if (isNaN(id)) return notFound();
 
@@ -65,8 +80,14 @@ export default new Hono<AppContext>()
       set("page_title", template.label);
       const status =
         req.query("status") === "created" ? ("created" as const) : undefined;
-      const is_editor = hyyyper_user.role !== "visitor";
-      return render(<DetailPage template={template} status={status} is_editor={is_editor} />);
+      const is_editor = hyyyper_user.role !== roles.enum.visitor;
+      return render(
+        <DetailPage
+          template={template}
+          status={status}
+          is_editor={is_editor}
+        />,
+      );
     },
   )
   .use(editor_guard())

--- a/sources/web/src/routes/response-templates/index.tsx
+++ b/sources/web/src/routes/response-templates/index.tsx
@@ -1,7 +1,7 @@
 //
 
 import { Main_Layout } from "#src/layouts";
-import { authorized } from "#src/middleware/auth";
+import { authorized, editor_guard } from "#src/middleware/auth";
 import type { AppContext } from "#src/middleware/context";
 import { zValidator } from "@hono/zod-validator";
 import { schema } from "@~/hyyyperbase";
@@ -44,22 +44,6 @@ export default new Hono<AppContext>()
     set("page_title", "Nouveau template");
     return render(<DetailPage />);
   })
-  .post(
-    "/",
-    zValidator("form", TemplateFormSchema),
-    async function POST({ req, redirect, var: { hyyyper_pg } }) {
-      const { label, content, end_user_reason, allow_editing } =
-        req.valid("form");
-      const [inserted] = await hyyyper_pg
-        .insert(schema.response_templates)
-        .values({ label, content, end_user_reason, allow_editing })
-        .returning({ id: schema.response_templates.id });
-      return redirect(
-        `/response-templates/${inserted!.id}?status=created`,
-        303,
-      );
-    },
-  )
   .get(
     "/:id",
     jsxRenderer(Main_Layout),
@@ -74,6 +58,23 @@ export default new Hono<AppContext>()
       const status =
         req.query("status") === "created" ? ("created" as const) : undefined;
       return render(<DetailPage template={template} status={status} />);
+    },
+  )
+  .use(editor_guard())
+  .post(
+    "/",
+    zValidator("form", TemplateFormSchema),
+    async function POST({ req, redirect, var: { hyyyper_pg } }) {
+      const { label, content, end_user_reason, allow_editing } =
+        req.valid("form");
+      const [inserted] = await hyyyper_pg
+        .insert(schema.response_templates)
+        .values({ label, content, end_user_reason, allow_editing })
+        .returning({ id: schema.response_templates.id });
+      return redirect(
+        `/response-templates/${inserted!.id}?status=created`,
+        303,
+      );
     },
   )
   .patch(

--- a/sources/web/src/routes/response-templates/index.tsx
+++ b/sources/web/src/routes/response-templates/index.tsx
@@ -33,21 +33,29 @@ export default new Hono<AppContext>()
   .get(
     "/",
     jsxRenderer(Main_Layout),
-    async function GET({ render, set, req, var: { hyyyper_pg } }) {
+    async function GET({ render, set, req, var: { hyyyper_pg, hyyyper_user } }) {
       set("page_title", "Templates de réponse");
       const searchQuery = req.query("q") ?? "";
       const templates = await get_response_templates(hyyyper_pg, searchQuery);
-      return render(<Page templates={templates} searchQuery={searchQuery} />);
+      const is_editor = hyyyper_user.role !== "visitor";
+      return render(
+        <Page templates={templates} searchQuery={searchQuery} is_editor={is_editor} />,
+      );
     },
   )
-  .get("/new", jsxRenderer(Main_Layout), function GET({ render, set }) {
-    set("page_title", "Nouveau template");
-    return render(<DetailPage />);
-  })
+  .get(
+    "/new",
+    jsxRenderer(Main_Layout),
+    function GET({ render, set, var: { hyyyper_user } }) {
+      set("page_title", "Nouveau template");
+      const is_editor = hyyyper_user.role !== "visitor";
+      return render(<DetailPage is_editor={is_editor} />);
+    },
+  )
   .get(
     "/:id",
     jsxRenderer(Main_Layout),
-    async function GET({ render, set, req, var: { hyyyper_pg }, notFound }) {
+    async function GET({ render, set, req, var: { hyyyper_pg, hyyyper_user }, notFound }) {
       const id = parseInt(req.param("id"), 10);
       if (isNaN(id)) return notFound();
 
@@ -57,7 +65,8 @@ export default new Hono<AppContext>()
       set("page_title", template.label);
       const status =
         req.query("status") === "created" ? ("created" as const) : undefined;
-      return render(<DetailPage template={template} status={status} />);
+      const is_editor = hyyyper_user.role !== "visitor";
+      return render(<DetailPage template={template} status={status} is_editor={is_editor} />);
     },
   )
   .use(editor_guard())

--- a/sources/web/src/routes/response-templates/page.tsx
+++ b/sources/web/src/routes/response-templates/page.tsx
@@ -71,7 +71,11 @@ export default function Page({
         />
       </form>
 
-      <TemplateList templates={templates} searchQuery={searchQuery} is_editor={is_editor} />
+      <TemplateList
+        templates={templates}
+        searchQuery={searchQuery}
+        is_editor={is_editor}
+      />
     </main>
   );
 }
@@ -110,7 +114,11 @@ function TemplateList({
 
       <ul>
         {filteredTemplates.map((template) => (
-          <TemplateAccordion key={template.id} template={template} is_editor={is_editor} />
+          <TemplateAccordion
+            key={template.id}
+            template={template}
+            is_editor={is_editor}
+          />
         ))}
       </ul>
     </div>

--- a/sources/web/src/routes/response-templates/page.tsx
+++ b/sources/web/src/routes/response-templates/page.tsx
@@ -30,20 +30,24 @@ const hx_templates_query_props = {
 export default function Page({
   templates,
   searchQuery = "",
+  is_editor = false,
 }: {
   templates: PageTemplate[];
   searchQuery?: string;
+  is_editor?: boolean;
 }) {
   return (
     <main class="container mx-auto my-12 px-4">
       <div class="mb-6 flex items-baseline justify-between">
         <h1 class="mb-0">Templates de réponse</h1>
-        <a
-          href={urls["response-templates"].new.$url().pathname}
-          class={button()}
-        >
-          Nouveau template
-        </a>
+        {is_editor && (
+          <a
+            href={urls["response-templates"].new.$url().pathname}
+            class={button()}
+          >
+            Nouveau template
+          </a>
+        )}
       </div>
       <p class="mb-6 text-lg leading-7">
         Sélectionnez un template pour le visualiser et l'éditer.
@@ -67,7 +71,7 @@ export default function Page({
         />
       </form>
 
-      <TemplateList templates={templates} searchQuery={searchQuery} />
+      <TemplateList templates={templates} searchQuery={searchQuery} is_editor={is_editor} />
     </main>
   );
 }
@@ -75,9 +79,11 @@ export default function Page({
 function TemplateList({
   templates,
   searchQuery = "",
+  is_editor = false,
 }: {
   templates: PageTemplate[];
   searchQuery?: string;
+  is_editor?: boolean;
 }) {
   const query = searchQuery.toLowerCase().trim();
   const filteredTemplates = query
@@ -104,14 +110,20 @@ function TemplateList({
 
       <ul>
         {filteredTemplates.map((template) => (
-          <TemplateAccordion key={template.id} template={template} />
+          <TemplateAccordion key={template.id} template={template} is_editor={is_editor} />
         ))}
       </ul>
     </div>
   );
 }
 
-function TemplateAccordion({ template }: { template: PageTemplate }) {
+function TemplateAccordion({
+  template,
+  is_editor = false,
+}: {
+  template: PageTemplate;
+  is_editor?: boolean;
+}) {
   const accordionId = `accordion-${template.id}`;
 
   const { base, btn } = accordion();
@@ -119,16 +131,18 @@ function TemplateAccordion({ template }: { template: PageTemplate }) {
     <details class={base()} open={undefined}>
       <summary class={btn()}>
         <span class="flex-1">{template.label}</span>
-        <a
-          href={`/response-templates/${template.id}`}
-          class={button({
-            intent: "ghost",
-            size: "sm",
-            class: "mr-2",
-          })}
-        >
-          Éditer
-        </a>
+        {is_editor && (
+          <a
+            href={`/response-templates/${template.id}`}
+            class={button({
+              intent: "ghost",
+              size: "sm",
+              class: "mr-2",
+            })}
+          >
+            Éditer
+          </a>
+        )}
       </summary>
       <div id={accordionId}>
         <TemplatePreview template={template} />

--- a/sources/web/src/ui/moderations/Actions/Actions.client.tsx
+++ b/sources/web/src/ui/moderations/Actions/Actions.client.tsx
@@ -33,57 +33,59 @@ export function ActionsClient({
 }: ActionsClientProps) {
   return (
     <>
-      {is_editor && <div
-        class="bg-surface border-border fixed right-0 bottom-0 z-50 flex w-full justify-end overflow-hidden border-t p-2"
-        role="toolbar"
-      >
-        {!moderated_at && (
-          <>
-            <button
-              class={button({
-                type: "secondary",
-                class: "bg-background dark:bg-surface mr-4",
-              })}
-              type="button"
-              onClick={() => {
-                toolbar_open.value =
-                  toolbar_open.value === "accept" ? null : "accept";
-              }}
-            >
-              ✅ Accepter
-            </button>
-            <button
-              class={button({
-                type: "secondary",
-                class: "bg-background dark:bg-surface mr-4",
-              })}
-              type="button"
-              onClick={() => {
-                toolbar_open.value =
-                  toolbar_open.value === "refusal" ? null : "refusal";
-              }}
-            >
-              ❌ Refuser
-            </button>
-          </>
-        )}
-        <a
-          href="#exchange_moderation"
-          class={button({
-            type: "secondary",
-            class: "bg-background dark:bg-surface",
-          })}
-          onClick={() => {
-            toolbar_open.value = null;
-            const details = document.getElementById(
-              "exchange_details",
-            ) as HTMLDetailsElement | null;
-            if (details) details.open = true;
-          }}
+      {is_editor && (
+        <div
+          class="bg-surface border-border fixed right-0 bottom-0 z-50 flex w-full justify-end overflow-hidden border-t p-2"
+          role="toolbar"
         >
-          💬 Voir les échanges
-        </a>
-      </div>}
+          {!moderated_at && (
+            <>
+              <button
+                class={button({
+                  type: "secondary",
+                  class: "bg-background dark:bg-surface mr-4",
+                })}
+                type="button"
+                onClick={() => {
+                  toolbar_open.value =
+                    toolbar_open.value === "accept" ? null : "accept";
+                }}
+              >
+                ✅ Accepter
+              </button>
+              <button
+                class={button({
+                  type: "secondary",
+                  class: "bg-background dark:bg-surface mr-4",
+                })}
+                type="button"
+                onClick={() => {
+                  toolbar_open.value =
+                    toolbar_open.value === "refusal" ? null : "refusal";
+                }}
+              >
+                ❌ Refuser
+              </button>
+            </>
+          )}
+          <a
+            href="#exchange_moderation"
+            class={button({
+              type: "secondary",
+              class: "bg-background dark:bg-surface",
+            })}
+            onClick={() => {
+              toolbar_open.value = null;
+              const details = document.getElementById(
+                "exchange_details",
+              ) as HTMLDetailsElement | null;
+              if (details) details.open = true;
+            }}
+          >
+            💬 Voir les échanges
+          </a>
+        </div>
+      )}
       {is_editor && (
         <>
           <AcceptForm

--- a/sources/web/src/ui/moderations/Actions/Actions.client.tsx
+++ b/sources/web/src/ui/moderations/Actions/Actions.client.tsx
@@ -31,79 +31,75 @@ export function ActionsClient({
   response_templates,
   is_editor = true,
 }: ActionsClientProps) {
+  if (!is_editor) return null;
+
   return (
     <>
-      {is_editor && (
-        <div
-          class="bg-surface border-border fixed right-0 bottom-0 z-50 flex w-full justify-end overflow-hidden border-t p-2"
-          role="toolbar"
+      <div
+        class="bg-surface border-border fixed right-0 bottom-0 z-50 flex w-full justify-end overflow-hidden border-t p-2"
+        role="toolbar"
+      >
+        {!moderated_at && (
+          <>
+            <button
+              class={button({
+                type: "secondary",
+                class: "bg-background dark:bg-surface mr-4",
+              })}
+              type="button"
+              onClick={() => {
+                toolbar_open.value =
+                  toolbar_open.value === "accept" ? null : "accept";
+              }}
+            >
+              ✅ Accepter
+            </button>
+            <button
+              class={button({
+                type: "secondary",
+                class: "bg-background dark:bg-surface mr-4",
+              })}
+              type="button"
+              onClick={() => {
+                toolbar_open.value =
+                  toolbar_open.value === "refusal" ? null : "refusal";
+              }}
+            >
+              ❌ Refuser
+            </button>
+          </>
+        )}
+        <a
+          href="#exchange_moderation"
+          class={button({
+            type: "secondary",
+            class: "bg-background dark:bg-surface",
+          })}
+          onClick={() => {
+            toolbar_open.value = null;
+            const details = document.getElementById(
+              "exchange_details",
+            ) as HTMLDetailsElement | null;
+            if (details) details.open = true;
+          }}
         >
-          {!moderated_at && (
-            <>
-              <button
-                class={button({
-                  type: "secondary",
-                  class: "bg-background dark:bg-surface mr-4",
-                })}
-                type="button"
-                onClick={() => {
-                  toolbar_open.value =
-                    toolbar_open.value === "accept" ? null : "accept";
-                }}
-              >
-                ✅ Accepter
-              </button>
-              <button
-                class={button({
-                  type: "secondary",
-                  class: "bg-background dark:bg-surface mr-4",
-                })}
-                type="button"
-                onClick={() => {
-                  toolbar_open.value =
-                    toolbar_open.value === "refusal" ? null : "refusal";
-                }}
-              >
-                ❌ Refuser
-              </button>
-            </>
-          )}
-          <a
-            href="#exchange_moderation"
-            class={button({
-              type: "secondary",
-              class: "bg-background dark:bg-surface",
-            })}
-            onClick={() => {
-              toolbar_open.value = null;
-              const details = document.getElementById(
-                "exchange_details",
-              ) as HTMLDetailsElement | null;
-              if (details) details.open = true;
-            }}
-          >
-            💬 Voir les échanges
-          </a>
-        </div>
-      )}
-      {is_editor && (
-        <>
-          <AcceptForm
-            moderation_id={moderation_id}
-            domain={domain}
-            given_name={given_name}
-            user_email={user_email}
-            organization_name={organization_name}
-            moderation_type={moderation_type}
-          />
-          <RefusalForm
-            moderation_id={moderation_id}
-            user_email={user_email}
-            organization_name={organization_name}
-            response_templates={response_templates}
-          />
-        </>
-      )}
+          💬 Voir les échanges
+        </a>
+      </div>
+      <AcceptForm
+        moderation_id={moderation_id}
+        domain={domain}
+        given_name={given_name}
+        user_email={user_email}
+        organization_name={organization_name}
+        moderation_type={moderation_type}
+      />
+      <RefusalForm
+        moderation_id={moderation_id}
+        user_email={user_email}
+        organization_name={organization_name}
+        response_templates={response_templates}
+      />
     </>
   );
 }

--- a/sources/web/src/ui/moderations/Actions/Actions.client.tsx
+++ b/sources/web/src/ui/moderations/Actions/Actions.client.tsx
@@ -17,6 +17,7 @@ export interface ActionsClientProps extends Record<string, unknown> {
   organization_name: string | null;
   moderation_type: string;
   response_templates: ResponseTemplateDto[];
+  is_editor?: boolean;
 }
 
 export function ActionsClient({
@@ -28,10 +29,11 @@ export function ActionsClient({
   organization_name,
   moderation_type,
   response_templates,
+  is_editor = true,
 }: ActionsClientProps) {
   return (
     <>
-      <div
+      {is_editor && <div
         class="bg-surface border-border fixed right-0 bottom-0 z-50 flex w-full justify-end overflow-hidden border-t p-2"
         role="toolbar"
       >
@@ -81,21 +83,25 @@ export function ActionsClient({
         >
           💬 Voir les échanges
         </a>
-      </div>
-      <AcceptForm
-        moderation_id={moderation_id}
-        domain={domain}
-        given_name={given_name}
-        user_email={user_email}
-        organization_name={organization_name}
-        moderation_type={moderation_type}
-      />
-      <RefusalForm
-        moderation_id={moderation_id}
-        user_email={user_email}
-        organization_name={organization_name}
-        response_templates={response_templates}
-      />
+      </div>}
+      {is_editor && (
+        <>
+          <AcceptForm
+            moderation_id={moderation_id}
+            domain={domain}
+            given_name={given_name}
+            user_email={user_email}
+            organization_name={organization_name}
+            moderation_type={moderation_type}
+          />
+          <RefusalForm
+            moderation_id={moderation_id}
+            user_email={user_email}
+            organization_name={organization_name}
+            response_templates={response_templates}
+          />
+        </>
+      )}
     </>
   );
 }

--- a/sources/web/src/ui/moderations/Actions/Actions.tsx
+++ b/sources/web/src/ui/moderations/Actions/Actions.tsx
@@ -10,9 +10,10 @@ import { ActionsIsland } from "./ActionsIsland";
 type ActionProps = {
   moderation: GetModerationWithDetailsDto;
   response_templates: ResponseTemplateDto[];
+  is_editor?: boolean;
 };
 
-export async function Actions({ moderation, response_templates }: ActionProps) {
+export async function Actions({ moderation, response_templates, is_editor = true }: ActionProps) {
   const domain = z_email_domain.parse(moderation.user.email);
 
   return (
@@ -25,6 +26,7 @@ export async function Actions({ moderation, response_templates }: ActionProps) {
       organization_name={moderation.organization.cached_libelle}
       moderation_type={moderation.type}
       response_templates={response_templates}
+      is_editor={is_editor}
     />
   );
 }

--- a/sources/web/src/ui/moderations/Actions/Actions.tsx
+++ b/sources/web/src/ui/moderations/Actions/Actions.tsx
@@ -13,7 +13,11 @@ type ActionProps = {
   is_editor?: boolean;
 };
 
-export async function Actions({ moderation, response_templates, is_editor = true }: ActionProps) {
+export async function Actions({
+  moderation,
+  response_templates,
+  is_editor = true,
+}: ActionProps) {
   const domain = z_email_domain.parse(moderation.user.email);
 
   return (


### PR DESCRIPTION
**Problem**

Authenticated users with the visitor role could perform DB
mutations (response-templates CRUD, org member updates,
moderation actions) despite having no editing authority.

**Proposal**

Add editor_guard() middleware (allows admin + moderator, redirects
visitor) and apply it before all write routes: response-templates
POST/PATCH/DELETE, organizations members PATCH/DELETE, and the
four moderation action routes (validate/rejected/processed/reprocess).