### PR TITLE
🛂 Hide editor actions from visitors

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -104,5 +104,6 @@ jobs:
           - moderations/verify_domain.feature
           - organizations
           - response-templates
+          - security/visitor_read_only.feature
           - team
           - users

--- a/.release-it-changeset/247388145_bug.md
+++ b/.release-it-changeset/247388145_bug.md
@@ -1,0 +1,3 @@
+🛂 Masquage des actions d'édition pour les visiteurs
+
+Les visiteurs (rôle en lecture seule) ne voient plus les actions destructrices (suppression de domaine, réinitialisation d'utilisateur, réinitialisation de vérification d'email). Ces contrôles sont désormais réservés aux éditeurs (modérateurs/administrateurs)

--- a/e2e/features/delivrability-domain/delivrability-email-domain.feature
+++ b/e2e/features/delivrability-domain/delivrability-email-domain.feature
@@ -5,7 +5,7 @@ Fonctionnalité: Gestion de la délivrabilité des domaines email
     Soit une base de données nourrie au grain
     Quand je navigue sur la page
     Et je vois "Bonjour Hyyypertool !"
-    Et je me connecte en tant que "jeanbon@yopmail.com"
+    Et je me connecte en tant que "moderateur@beta.gouv.fr"
 
   Scénario: Afficher la liste des domaines en whitelist
     Quand je clique sur "Délivrabilité des domaines"

--- a/e2e/features/moderations/add_external_member.feature
+++ b/e2e/features/moderations/add_external_member.feature
@@ -21,6 +21,7 @@ Fonctionnalité: Ajouter un membre externe lors de la modération
     Et je clique sur "Ajouter Marie à l'organisation EN TANT QU'EXTERNE"
     Et je clique sur "Terminer"
     Et je réinitialise le contexte
+    Quand je clique sur "Retour immédiat"
 
     Alors une notification mail n'est pas envoyée
 
@@ -50,6 +51,7 @@ Fonctionnalité: Ajouter un membre externe lors de la modération
     Et je clique sur "Notifier marie.bon@fr.bosch.com du traitement de la modération."
     Et je clique sur "Terminer"
     Et je réinitialise le contexte
+    Quand je clique sur "Retour immédiat"
 
     Alors une notification mail est envoyée
 

--- a/e2e/features/moderations/add_internal_member.feature
+++ b/e2e/features/moderations/add_internal_member.feature
@@ -21,6 +21,7 @@ Fonctionnalité: Ajouter un membre interne lors de la modération
     Et je clique sur "Ajouter Marie à l'organisation EN TANT QU'INTERNE"
     Quand je clique sur "Terminer"
     Et je réinitialise le contexte
+    Quand je clique sur "Retour immédiat"
 
     Alors une notification mail n'est pas envoyée
 
@@ -41,5 +42,6 @@ Fonctionnalité: Ajouter un membre interne lors de la modération
     Et je clique sur "Ajouter Raphael à l'organisation EN TANT QU'INTERNE"
     Quand je clique sur "Terminer"
     Et je réinitialise le contexte
+    Quand je clique sur "Retour immédiat"
 
     Alors je vois "Liste des moderations"

--- a/e2e/features/organizations/yes_we_hack_domain_verification.feature
+++ b/e2e/features/organizations/yes_we_hack_domain_verification.feature
@@ -5,7 +5,7 @@ Fonctionnalité: Page organisation - domaine à vérifier
     Soit une base de données nourrie au grain
     Quand je navigue sur la page
     Et je vois "Bonjour Hyyypertool !"
-    Et je me connecte en tant que "jeanbon@yopmail.com"
+    Et je me connecte en tant que "moderateur@beta.gouv.fr"
 
   Scénario:
     Quand je clique sur "Domaines à vérifier"

--- a/e2e/features/security/visitor_read_only.feature
+++ b/e2e/features/security/visitor_read_only.feature
@@ -28,3 +28,22 @@ Fonctionnalité: Un visiteur ne peut pas modifier les données
     Quand je clique sur le lien nommé "Modération a traiter de Jean Bon pour 13002526500013"
     Alors je ne vois pas "✅ Accepter"
     Et je ne vois pas "❌ Refuser"
+
+  Scénario: Le visiteur ne voit pas les actions sur un utilisateur
+    Etant donné que je suis sur la page "/users"
+    Quand je clique sur le lien nommé "Utilisateur Jean Bon (jeanbon@yopmail.com)"
+    Alors je ne vois pas "réinitialiser la vérification de l'email"
+    Et je ne vois pas "supprimer définitivement ce compte"
+
+  Scénario: Le visiteur ne voit pas les actions sur les domaines d'une organisation
+    Quand je clique sur "Organisations"
+    Alors je suis redirigé sur "/organizations"
+    Quand je clique sur le lien nommé "Organisation Direction interministerielle du numerique (DINUM) (13002526500013)"
+    Alors je ne vois pas "Ajouter"
+    Et je ne vois pas "Supprimer"
+
+  Scénario: Le visiteur ne voit pas les actions sur la délivrabilité des domaines
+    Etant donné que je suis sur la page "/domains-deliverability"
+    Alors je vois "Délivrabilité des domaines"
+    Mais je ne vois pas "Ajouter un email problématique"
+    Et je ne vois pas "Supprimer test@ch-lehavre.fr"

--- a/sources/web/src/routes/domains-deliverability/AddDomain.tsx
+++ b/sources/web/src/routes/domains-deliverability/AddDomain.tsx
@@ -3,7 +3,8 @@ import { button } from "#src/ui/button";
 import { input, input_group, label } from "#src/ui/form";
 import { urls } from "#src/urls";
 
-export async function AddDomain() {
+export async function AddDomain({ is_editor }: { is_editor: boolean }) {
+  if (!is_editor) return <></>;
   const $describedby = hyper_ref("add_problematic_email");
 
   const hx_add_props = urls["domains-deliverability"].$hx_put();

--- a/sources/web/src/routes/domains-deliverability/Table.tsx
+++ b/sources/web/src/routes/domains-deliverability/Table.tsx
@@ -10,8 +10,10 @@ type EmailDelivrabilityWhiteList = Awaited<
 
 export async function Table({
   whitelist,
+  is_editor,
 }: {
   whitelist: EmailDelivrabilityWhiteList[];
+  is_editor: boolean;
 }) {
   return (
     <table class={table()}>
@@ -26,7 +28,11 @@ export async function Table({
       </thead>
       <tbody>
         {whitelist.map((item) => (
-          <Row key={item.email_domain} whitelist_item={item} />
+          <Row
+            key={item.email_domain}
+            whitelist_item={item}
+            is_editor={is_editor}
+          />
         ))}
       </tbody>
     </table>
@@ -36,18 +42,14 @@ export async function Table({
 async function Row({
   key,
   whitelist_item,
+  is_editor,
 }: {
   key?: string;
   whitelist_item: EmailDelivrabilityWhiteList;
+  is_editor: boolean;
 }) {
   const { verified_at, problematic_email, email_domain, verified_by } =
     whitelist_item;
-
-  const hx_delete_props = urls["domains-deliverability"][
-    ":email_domain"
-  ].$hx_delete({
-    param: { email_domain: email_domain },
-  });
 
   return (
     <tr aria-label={`Domaine ${email_domain}`} key={key}>
@@ -58,16 +60,38 @@ async function Row({
         <LocalTime date={verified_at} />
       </td>
       <td>
-        <button
-          {...hx_delete_props}
-          hx-confirm={`Êtes-vous sûr de vouloir supprimer le domaine « ${email_domain} » de la liste des emails délivrables ?`}
-          hx-swap="none"
-          type="button"
-          aria-label={`Supprimer ${problematic_email}`}
-        >
-          <Svg name={"delete"} />
-        </button>
+        <DeliverabilityRowActions
+          whitelist_item={whitelist_item}
+          is_editor={is_editor}
+        />
       </td>
     </tr>
+  );
+}
+
+function DeliverabilityRowActions({
+  whitelist_item,
+  is_editor,
+}: {
+  whitelist_item: EmailDelivrabilityWhiteList;
+  is_editor: boolean;
+}) {
+  if (!is_editor) return <></>;
+  const { problematic_email, email_domain } = whitelist_item;
+  const hx_delete_props = urls["domains-deliverability"][
+    ":email_domain"
+  ].$hx_delete({
+    param: { email_domain: email_domain },
+  });
+  return (
+    <button
+      {...hx_delete_props}
+      hx-confirm={`Êtes-vous sûr de vouloir supprimer le domaine « ${email_domain} » de la liste des emails délivrables ?`}
+      hx-swap="none"
+      type="button"
+      aria-label={`Supprimer ${problematic_email}`}
+    >
+      <Svg name={"delete"} />
+    </button>
   );
 }

--- a/sources/web/src/routes/domains-deliverability/index.tsx
+++ b/sources/web/src/routes/domains-deliverability/index.tsx
@@ -2,10 +2,11 @@
 
 import type { HtmxHeader } from "#src/htmx";
 import { Main_Layout } from "#src/layouts";
-import { authorized } from "#src/middleware/auth";
+import { authorized, editor_guard } from "#src/middleware/auth";
 import type { AppContext } from "#src/middleware/context";
 import { z_username } from "#src/schema";
 import { zValidator } from "@hono/zod-validator";
+import { roles } from "@~/hyyyperbase";
 import { schema } from "@~/identite-proconnect/database";
 import { eq } from "drizzle-orm";
 import { Hono } from "hono";
@@ -27,17 +28,19 @@ export default new Hono<AppContext>()
     "/",
     jsxRenderer(Main_Layout),
 
-    async function GET({ render, set, var: { identite_pg } }) {
+    async function GET({ render, set, var: { identite_pg, hyyyper_user } }) {
+      const is_editor = hyyyper_user.role !== roles.enum.visitor;
       const whitelist = await get_email_deliverability_whitelist(identite_pg);
 
       set("page_title", "Délivrabilité des domaines");
       return render(
         <>
-          <Page whitelist={whitelist} />
+          <Page whitelist={whitelist} is_editor={is_editor} />
         </>,
       );
     },
   )
+  .use(editor_guard())
   .put(
     "/",
     zValidator("form", z.object({ problematic_email: z.string().min(1) })),

--- a/sources/web/src/routes/domains-deliverability/page.tsx
+++ b/sources/web/src/routes/domains-deliverability/page.tsx
@@ -6,7 +6,13 @@ type Whitelist = Awaited<
   ReturnType<typeof get_email_deliverability_whitelist>
 >[number];
 
-export default async function Page({ whitelist }: { whitelist: Whitelist[] }) {
+export default async function Page({
+  whitelist,
+  is_editor,
+}: {
+  whitelist: Whitelist[];
+  is_editor: boolean;
+}) {
   return (
     <main class="container mx-auto my-12 px-4">
       <h1>Délivrabilité des domaines</h1>
@@ -17,8 +23,8 @@ export default async function Page({ whitelist }: { whitelist: Whitelist[] }) {
           hx-trigger="domains-deliverability-updated"
           hx-swap="innerHTML"
         >
-          <AddDomain />
-          <Table whitelist={whitelist} />
+          <AddDomain is_editor={is_editor} />
+          <Table whitelist={whitelist} is_editor={is_editor} />
         </div>
       </div>
     </main>

--- a/sources/web/src/routes/organizations/:id/domains/Table.tsx
+++ b/sources/web/src/routes/organizations/:id/domains/Table.tsx
@@ -25,9 +25,11 @@ type Domains = Awaited<ReturnType<typeof get_organization_domains>>;
 export function Table({
   domains,
   describedby,
+  is_editor,
 }: {
   domains: Domains;
   describedby: string;
+  is_editor: boolean;
 }) {
   return (
     <table class={table()} aria-describedby={describedby}>
@@ -43,7 +45,11 @@ export function Table({
       </thead>
       <tbody>
         {domains.map((domain) => (
-          <Row key={`${domain.id}`} organization_domain={domain} />
+          <Row
+            key={`${domain.id}`}
+            organization_domain={domain}
+            is_editor={is_editor}
+          />
         ))}
       </tbody>
     </table>
@@ -52,9 +58,12 @@ export function Table({
 
 export async function AddDomain({
   organization_id,
+  is_editor,
 }: {
   organization_id: number;
+  is_editor: boolean;
 }) {
+  if (!is_editor) return <></>;
   const $describedby = hyper_ref("add_domain");
 
   const hx_add_domain_props = urls.organizations[":id"].domains.$hx_put({
@@ -129,9 +138,11 @@ function TypeToEmoji({ type }: { type: EmailDomainVerificationType }) {
 function Row({
   key,
   organization_domain,
+  is_editor,
 }: {
   key?: string;
   organization_domain: Domains[number];
+  is_editor: boolean;
 }) {
   const {
     created_at,
@@ -173,13 +184,27 @@ function Row({
         >
           Vérifier le matching
         </GoogleSearchButton>
-        <Row_Actions organization_domain={organization_domain} />
+        <DomainRowActions
+          organization_domain={organization_domain}
+          is_editor={is_editor}
+        />
       </td>
     </tr>
   );
 }
 
-async function Row_Actions({
+function DomainRowActions({
+  organization_domain,
+  is_editor,
+}: {
+  organization_domain: Domains[number];
+  is_editor: boolean;
+}) {
+  if (!is_editor) return <></>;
+  return <RowActions organization_domain={organization_domain} />;
+}
+
+async function RowActions({
   organization_domain,
 }: {
   organization_domain: Domains[number];

--- a/sources/web/src/routes/organizations/:id/domains/index.test.ts
+++ b/sources/web/src/routes/organizations/:id/domains/index.test.ts
@@ -1,12 +1,18 @@
 //
 
-import { set_userinfo } from "#src/middleware/auth";
+import { authorized, set_userinfo } from "#src/middleware/auth";
 import { set_config } from "#src/middleware/config";
+import { set_hyyyper_pg } from "#src/middleware/hyyyperbase";
 import {
   set_identite_pg,
   set_identite_pg_client,
 } from "#src/middleware/identite-pg";
 import { set_nonce } from "#src/middleware/nonce";
+import {
+  hyyyper_pglite,
+  empty_database as hyyyperbase_empty_database,
+} from "@~/hyyyperbase/testing";
+import { insert_moderateur } from "@~/hyyyperbase/testing/users";
 import { schema } from "@~/identite-proconnect/database";
 import {
   create_adora_pony_user,
@@ -33,11 +39,13 @@ import app from "./index";
 
 beforeAll(migrate);
 beforeEach(empty_database);
+beforeEach(hyyyperbase_empty_database);
 setSystemTime(new Date("2222-01-01T00:00:00.000Z"));
 
 //
 
 test("GET /organizations/:id/domains returns domains for organization", async () => {
+  const moderator = await insert_moderateur(hyyyper_pglite);
   const organization_id = await create_unicorn_organization(pg);
 
   await pg.insert(schema.email_domains).values({
@@ -48,9 +56,11 @@ test("GET /organizations/:id/domains returns domains for organization", async ()
 
   const response = await new Hono()
     .use(set_config({}))
+    .use(set_hyyyper_pg(hyyyper_pglite))
     .use(set_identite_pg(pg))
     .use(set_nonce("nonce"))
-    .use(set_userinfo({ email: "test@example.com" }))
+    .use(set_userinfo({ email: moderator.email, sub: moderator.sub! }))
+    .use(authorized())
     .route("/:id/domains", app)
     .request(`/${organization_id}/domains?describedby=test-id`);
 
@@ -62,6 +72,7 @@ test("GET /organizations/:id/domains returns domains for organization", async ()
 });
 
 test("PUT /organizations/:id/domains adds new domain", async () => {
+  const moderator = await insert_moderateur(hyyyper_pglite);
   const organization_id = await create_unicorn_organization(pg);
   const adora_pony_user_id = await create_adora_pony_user(pg);
   const pink_diamond_user_id = await create_pink_diamond_user(pg);
@@ -105,10 +116,12 @@ test("PUT /organizations/:id/domains adds new domain", async () => {
 
   const response = await new Hono()
     .use(set_config({}))
+    .use(set_hyyyper_pg(hyyyper_pglite))
     .use(set_identite_pg(pg))
     .use(set_identite_pg_client(client as any))
     .use(set_nonce("nonce"))
-    .use(set_userinfo({ email: "test@example.com" }))
+    .use(set_userinfo({ email: moderator.email, sub: moderator.sub! }))
+    .use(authorized())
     .route("/:id/domains", app)
     .request(`/${organization_id}/domains`, {
       method: "PUT",
@@ -192,6 +205,7 @@ test("PUT /organizations/:id/domains adds new domain", async () => {
 });
 
 test("DELETE /organizations/:id/domains/:domain_id removes domain", async () => {
+  const moderator = await insert_moderateur(hyyyper_pglite);
   const organization_id = await create_unicorn_organization(pg);
 
   const [{ id: domain_id } = { id: NaN }] = await pg
@@ -205,9 +219,11 @@ test("DELETE /organizations/:id/domains/:domain_id removes domain", async () => 
 
   const response = await new Hono()
     .use(set_config({}))
+    .use(set_hyyyper_pg(hyyyper_pglite))
     .use(set_identite_pg(pg))
     .use(set_nonce("nonce"))
-    .use(set_userinfo({ email: "test@example.com" }))
+    .use(set_userinfo({ email: moderator.email, sub: moderator.sub! }))
+    .use(authorized())
     .route("/:id/domains", app)
     .request(`/${organization_id}/domains/${domain_id}`, {
       method: "DELETE",
@@ -238,6 +254,7 @@ test("DELETE /organizations/:id/domains/:domain_id removes domain", async () => 
 });
 
 test("PATCH /organizations/:id/domains/:domain_id updates verification type to verified", async () => {
+  const moderator = await insert_moderateur(hyyyper_pglite);
   const organization_id = await create_unicorn_organization(pg);
   const adora_pony_user_id = await create_adora_pony_user(pg);
   const pink_diamond_user_id = await create_pink_diamond_user(pg);
@@ -271,10 +288,12 @@ test("PATCH /organizations/:id/domains/:domain_id updates verification type to v
 
   const response = await new Hono()
     .use(set_config({}))
+    .use(set_hyyyper_pg(hyyyper_pglite))
     .use(set_identite_pg(pg))
     .use(set_identite_pg_client(client as any))
     .use(set_nonce("nonce"))
-    .use(set_userinfo({ email: "test@example.com" }))
+    .use(set_userinfo({ email: moderator.email, sub: moderator.sub! }))
+    .use(authorized())
     .route("/:id/domains", app)
     .request(`/${organization_id}/domains/${domain_id}?type=verified`, {
       method: "PATCH",

--- a/sources/web/src/routes/organizations/:id/domains/index.tsx
+++ b/sources/web/src/routes/organizations/:id/domains/index.tsx
@@ -8,9 +8,11 @@ import {
   GetFicheOrganizationById,
   RemoveDomainEmailById,
 } from "#src/lib/organizations/usecase";
+import { editor_guard } from "#src/middleware/auth";
 import type { AppContext } from "#src/middleware/context";
 import { DescribedBySchema, EntitySchema, IdSchema } from "#src/schema";
 import { zValidator } from "@hono/zod-validator";
+import { roles } from "@~/hyyyperbase";
 import {
   createProconnectIdentiteContext,
   MarkDomainAsVerified,
@@ -35,11 +37,11 @@ export default new Hono<AppContext>()
     jsxRenderer(),
     zValidator("param", EntitySchema),
     zValidator("query", DescribedBySchema),
-    async function GET({ render, req, var: { identite_pg } }) {
+    async function GET({ render, req, var: { identite_pg, hyyyper_user } }) {
       const { id: organization_id } = req.valid("param");
       const { describedby } = req.valid("query");
 
-      // Load data directly in handler
+      const is_editor = hyyyper_user.role !== roles.enum.visitor;
       const domains = await get_organization_domains(
         { pg: identite_pg },
         { organization_id },
@@ -47,12 +49,17 @@ export default new Hono<AppContext>()
 
       return render(
         <>
-          <Table domains={domains} describedby={describedby} />
-          <AddDomain organization_id={organization_id} />
+          <Table
+            domains={domains}
+            describedby={describedby}
+            is_editor={is_editor}
+          />
+          <AddDomain organization_id={organization_id} is_editor={is_editor} />
         </>,
       );
     },
   )
+  .use(editor_guard())
   .put(
     "/",
     zValidator("param", EntitySchema),

--- a/sources/web/src/routes/users/:id/index.test.ts
+++ b/sources/web/src/routes/users/:id/index.test.ts
@@ -10,7 +10,10 @@ import {
   hyyyper_pglite,
   empty_database as hyyyperbase_empty_database,
 } from "@~/hyyyperbase/testing";
-import { insert_moderateur } from "@~/hyyyperbase/testing/users";
+import {
+  insert_jeanbon,
+  insert_moderateur,
+} from "@~/hyyyperbase/testing/users";
 import { schema } from "@~/identite-proconnect/database";
 import { create_adora_pony_user } from "@~/identite-proconnect/database/seed/unicorn";
 import {
@@ -62,13 +65,16 @@ test("GET /users/:id returns user details", async () => {
 });
 
 test("DELETE /users/:id deletes user and redirects", async () => {
+  const moderator = await insert_moderateur(hyyyper_pglite);
   const user_id = await create_adora_pony_user(pg);
 
   const response = await new Hono()
     .use(set_config({}))
+    .use(set_hyyyper_pg(hyyyper_pglite))
     .use(set_identite_pg(pg))
     .use(set_nonce("nonce"))
-    .use(set_userinfo({ email: "test@example.com" }))
+    .use(set_userinfo({ email: moderator.email, sub: moderator.sub! }))
+    .use(authorized())
     .route("/:id", app)
     .request(`/${user_id}`, { method: "DELETE" });
 
@@ -82,13 +88,16 @@ test("DELETE /users/:id deletes user and redirects", async () => {
 });
 
 test("PATCH /users/:id/reset/email_verified resets email verification", async () => {
+  const moderator = await insert_moderateur(hyyyper_pglite);
   const user_id = await create_adora_pony_user(pg);
 
   const response = await new Hono()
     .use(set_config({}))
+    .use(set_hyyyper_pg(hyyyper_pglite))
     .use(set_identite_pg(pg))
     .use(set_nonce("nonce"))
-    .use(set_userinfo({ email: "test@example.com" }))
+    .use(set_userinfo({ email: moderator.email, sub: moderator.sub! }))
+    .use(authorized())
     .route("/:id", app)
     .request(`/${user_id}/reset/email_verified`, { method: "PATCH" });
 
@@ -103,6 +112,7 @@ test("PATCH /users/:id/reset/email_verified resets email verification", async ()
 });
 
 test("PATCH /users/:id/reset/france_connect remove FranceConnect data", async () => {
+  const moderator = await insert_moderateur(hyyyper_pglite);
   const user_id = await create_adora_pony_user(pg);
   await pg.insert(schema.franceconnect_userinfo).values({
     created_at: "2022-01-01T00:00:00.000Z",
@@ -114,9 +124,11 @@ test("PATCH /users/:id/reset/france_connect remove FranceConnect data", async ()
   });
   const response = await new Hono()
     .use(set_config({}))
+    .use(set_hyyyper_pg(hyyyper_pglite))
     .use(set_identite_pg(pg))
     .use(set_nonce("nonce"))
-    .use(set_userinfo({ email: "test@example.com" }))
+    .use(set_userinfo({ email: moderator.email, sub: moderator.sub! }))
+    .use(authorized())
     .route("/:id", app)
     .onError((error) => {
       throw error;
@@ -133,6 +145,7 @@ test("PATCH /users/:id/reset/france_connect remove FranceConnect data", async ()
 });
 
 test("PATCH /users/:id/reset/password resets password", async () => {
+  const moderator = await insert_moderateur(hyyyper_pglite);
   const user_id = await create_adora_pony_user(pg);
 
   const mockCrisp = {
@@ -152,10 +165,12 @@ test("PATCH /users/:id/reset/password resets password", async () => {
         CRISP_KEY: "test",
       }),
     )
+    .use(set_hyyyper_pg(hyyyper_pglite))
     .use(set_crisp_client(mockCrisp))
     .use(set_identite_pg(pg))
     .use(set_nonce("nonce"))
-    .use(set_userinfo({ email: "test@example.com" }))
+    .use(set_userinfo({ email: moderator.email, sub: moderator.sub! }))
+    .use(authorized())
     .route("/:id", app)
     .request(`/${user_id}/reset/password`, { method: "PATCH" });
 
@@ -164,6 +179,7 @@ test("PATCH /users/:id/reset/password resets password", async () => {
 });
 
 test("PATCH /users/:id/reset/mfa resets MFA", async () => {
+  const moderator = await insert_moderateur(hyyyper_pglite);
   const user_id = await create_adora_pony_user(pg);
 
   const mockCrisp = {
@@ -183,13 +199,32 @@ test("PATCH /users/:id/reset/mfa resets MFA", async () => {
         CRISP_KEY: "test",
       }),
     )
+    .use(set_hyyyper_pg(hyyyper_pglite))
     .use(set_crisp_client(mockCrisp))
     .use(set_identite_pg(pg))
     .use(set_nonce("nonce"))
-    .use(set_userinfo({ email: "test@example.com" }))
+    .use(set_userinfo({ email: moderator.email, sub: moderator.sub! }))
+    .use(authorized())
     .route("/:id", app)
     .request(`/${user_id}/reset/mfa`, { method: "PATCH" });
 
   expect(response.status).toBe(200);
   expect(response.text()).resolves.toBe("OK");
+});
+
+test("GET /users/:id as visitor returns 200 (read-only access)", async () => {
+  const visitor = await insert_jeanbon(hyyyper_pglite);
+  const user_id = await create_adora_pony_user(pg);
+
+  const response = await new Hono()
+    .use(set_config({}))
+    .use(set_hyyyper_pg(hyyyper_pglite))
+    .use(set_identite_pg(pg))
+    .use(set_nonce("nonce"))
+    .use(set_userinfo({ email: visitor.email, sub: visitor.sub! }))
+    .use(authorized())
+    .route("/:id", app)
+    .request(`/${user_id}`);
+
+  expect(response.status).toBe(200);
 });

--- a/sources/web/src/routes/users/:id/index.tsx
+++ b/sources/web/src/routes/users/:id/index.tsx
@@ -4,10 +4,12 @@ import { NotFoundError } from "#src/errors";
 import type { HtmxHeader } from "#src/htmx";
 import { Main_Layout } from "#src/layouts";
 import { ResetMFA, ResetPassword } from "#src/lib/users";
+import { editor_guard } from "#src/middleware/auth";
 import type { AppContext } from "#src/middleware/context";
 import { EntitySchema } from "#src/schema";
 import { urls } from "#src/urls";
 import { zValidator } from "@hono/zod-validator";
+import { roles } from "@~/hyyyperbase";
 import { schema } from "@~/identite-proconnect/database";
 import { eq } from "drizzle-orm";
 import { Hono } from "hono";
@@ -28,8 +30,15 @@ export default new Hono<AppContext>()
     "/",
     jsxRenderer(Main_Layout),
     zValidator("param", EntitySchema),
-    async function GET({ render, req, set, status, var: { identite_pg } }) {
+    async function GET({
+      render,
+      req,
+      set,
+      status,
+      var: { identite_pg, hyyyper_user },
+    }) {
       const { id } = req.valid("param");
+      const is_editor = hyyyper_user.role !== roles.enum.visitor;
 
       try {
         const user = await get_user_by_id(identite_pg, id);
@@ -51,6 +60,7 @@ export default new Hono<AppContext>()
           <UserPage
             authenticators={authenticators}
             franceconnect={franceconnect}
+            is_editor={is_editor}
             user={user}
           />,
         );
@@ -63,6 +73,12 @@ export default new Hono<AppContext>()
       }
     },
   )
+  //
+  .route("/organizations", user_organizations_page_route)
+  .route("/moderations", user_moderations_route)
+  .route("/oidc_clients", user_oidc_clients_route)
+  //
+  .use(editor_guard())
   .delete(
     "/",
     zValidator("param", EntitySchema),
@@ -140,10 +156,6 @@ export default new Hono<AppContext>()
 
       return text("OK", 200, { "HX-Refresh": "true" } as HtmxHeader);
     },
-  )
-  //
-  .route("/organizations", user_organizations_page_route)
-  .route("/moderations", user_moderations_route)
-  .route("/oidc_clients", user_oidc_clients_route);
+  );
 
 //

--- a/sources/web/src/routes/users/:id/page.tsx
+++ b/sources/web/src/routes/users/:id/page.tsx
@@ -23,10 +23,12 @@ type User = Awaited<ReturnType<typeof get_user_by_id>>;
 export async function UserPage({
   authenticators,
   franceconnect,
+  is_editor,
   user,
 }: {
   authenticators: Authenticators;
   franceconnect: FranceConnect;
+  is_editor: boolean;
   user: User;
 }) {
   const $organizations_describedby = hyper_ref("user_organizations");
@@ -116,7 +118,7 @@ export async function UserPage({
       </div>
       <div class="bg-alt-red-marianne dark:bg-surface py-6">
         <div class="container mx-auto px-4 py-6">
-          <Actions user={user} />
+          <UserActions is_editor={is_editor} user={user} />
         </div>
       </div>
 
@@ -248,6 +250,11 @@ function FranceConnectInfo({
       </dl>
     </div>
   );
+}
+
+function UserActions({ is_editor, user }: { is_editor: boolean; user: User }) {
+  if (!is_editor) return null;
+  return <Actions user={user} />;
 }
 
 async function Actions({ user }: { user: User }) {


### PR DESCRIPTION
**Problem**

Visitors (read-only role) could see destructive actions like domain deletion, user reset, and email verification reset buttons. These controls should only be visible to editors (moderators/admins).

**Proposal**

Thread an `is_editor` flag (based on `hyyyper_user.role !== visitor`) through the users, domains-deliverability, and organization domains routes. Editor-only actions render nothing for visitors. Mutating endpoints are now guarded by `editor_guard()` while GET routes remain accessible. Add visitor read-only e2e scenarios and update unit tests to authenticate as a moderator.