### PR TITLE
🛂 Hide reprocess button from visitors

### DIFF
--- a/.release-it-changeset/1782485208-hide-reprocess-for-visitors.md
+++ b/.release-it-changeset/1782485208-hide-reprocess-for-visitors.md
@@ -1,0 +1,3 @@
+🔒 Masquage du bouton « Retraiter » pour les visiteurs
+
+Le bouton de retraitement d'une modération était visible par les visiteurs en lecture seule. Désormais, il ne s'affiche que pour les utilisateurs ayant les droits d'édition.

--- a/e2e/features/security/visitor_read_only.feature
+++ b/e2e/features/security/visitor_read_only.feature
@@ -29,6 +29,13 @@ Fonctionnalité: Un visiteur ne peut pas modifier les données
     Alors je ne vois pas "✅ Accepter"
     Et je ne vois pas "❌ Refuser"
 
+  Scénario: Le visiteur ne voit pas le bouton "Retraiter" sur une modération traitée
+    Etant donné que je suis sur la page "/moderations"
+    Quand je saisie le mot "{selectAll}is:processed{enter}" dans la boîte à texte nommée "Filtrer les modérations…"
+    Quand je clique sur le lien nommé "Modération a traiter de Richard Bon pour 38514019900014"
+    Alors je vois "Modération acceptée"
+    Mais je ne vois pas "Retraiter"
+
   Scénario: Le visiteur ne voit pas les actions sur un utilisateur
     Etant donné que je suis sur la page "/users"
     Quand je clique sur le lien nommé "Utilisateur Jean Bon (jeanbon@yopmail.com)"

--- a/sources/web/src/routes/moderations/:id/index.test.ts
+++ b/sources/web/src/routes/moderations/:id/index.test.ts
@@ -110,4 +110,32 @@ test("GET /moderations/:id hides action toolbar for visitors", async () => {
   expect(html).not.toContain("❌ Refuser");
 });
 
+test("GET /moderations/:id hides the reprocess button for visitors on a treated moderation", async () => {
+  const visitor = await insert_jeanbon(hyyyper_pglite);
+  await create_adora_pony_user(pg);
+  await create_unicorn_organization(pg);
+  const moderation_id = await create_adora_pony_moderation(pg, {
+    type: "non_verified_domain",
+    status: "accepted",
+    moderated_at: "2222-01-01T00:00:00.000Z",
+    moderated_by: "moderateur@beta.gouv.fr",
+  });
+
+  const response = await new Hono()
+    .use(set_config({ HTTP_CLIENT_TIMEOUT: 5000 }))
+    .use(set_hyyyper_pg(hyyyper_pglite))
+    .use(set_identite_pg(pg))
+    .use(set_nonce("nonce"))
+    .use(set_userinfo({ email: visitor.email, sub: visitor.sub! }))
+    .use(authorized())
+    .route("/:id", app)
+    .request(`/${moderation_id}`);
+
+  expect(response.status).toBe(200);
+  const html = await response.text();
+
+  expect(html).toContain("Modération acceptée");
+  expect(html).not.toContain("Retraiter");
+});
+
 //

--- a/sources/web/src/routes/moderations/:id/page.tsx
+++ b/sources/web/src/routes/moderations/:id/page.tsx
@@ -98,7 +98,7 @@ async function ModerationPageContent() {
         ])}
         id={moderation_id}
       >
-        <Header.Provier value={{ moderation }}>
+        <Header.Provier value={{ moderation, is_editor }}>
           <Header />
         </Header.Provier>
 

--- a/sources/web/src/ui/moderations/Header/Header.test.tsx
+++ b/sources/web/src/ui/moderations/Header/Header.test.tsx
@@ -26,6 +26,7 @@ test("render header section", async () => {
               id: 44,
             },
           },
+          is_editor: true,
         }}
       >
         <Header />

--- a/sources/web/src/ui/moderations/Header/Header.tsx
+++ b/sources/web/src/ui/moderations/Header/Header.tsx
@@ -32,6 +32,7 @@ const comment_item = tv({
 
 interface Values {
   moderation: GetModerationHeaderOutput;
+  is_editor: boolean;
 }
 const context = createContext<Values>({} as any);
 
@@ -170,7 +171,7 @@ function Info() {
 }
 
 async function ModerationCallout() {
-  const { moderation } = useContext(context);
+  const { moderation, is_editor } = useContext(context);
   if (!moderation.moderated_at) return raw``;
 
   const { base, text, title } = callout({
@@ -207,13 +208,15 @@ async function ModerationCallout() {
         .
       </p>
       <LastComment />
-      <button
-        class={button({ size: "sm", type: "tertiary" })}
-        {...hx_patch_moderation_reprocess}
-        hx-swap="none"
-      >
-        Retraiter
-      </button>
+      {is_editor ? (
+        <button
+          class={button({ size: "sm", type: "tertiary" })}
+          {...hx_patch_moderation_reprocess}
+          hx-swap="none"
+        >
+          Retraiter
+        </button>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
**Problem**

The "Retraiter" button on a treated moderation was still visible to visitors, bypassing the read-only restriction introduced in #1696.

**Proposal**

Gate the reprocess button behind the `is_editor` flag in the ModerationCallout, mirroring the existing pattern used for the accept/refuse toolbar. Add unit, snapshot and e2e coverage.