### PR TITLE
✨ Add verification type column to organizations table

### DIFF
--- a/.release-it-changeset/1783419337-verification-type-column.md
+++ b/.release-it-changeset/1783419337-verification-type-column.md
@@ -1,0 +1,3 @@
+✨ Ajout de la colonne « Type de vérification » dans le tableau des organisations
+
+Affiche le type de vérification de chaque organisation dans une nouvelle colonne du tableau.

--- a/sources/web/src/routes/users/:id/organizations/Table.tsx
+++ b/sources/web/src/routes/users/:id/organizations/Table.tsx
@@ -50,6 +50,7 @@ export async function Table({
           <th class="warp-break-word">Siret</th>
           <th class="warp-break-word">Libellé</th>
           <th class="warp-break-word">Domains</th>
+          <th class="warp-break-word">Type de vérification</th>
           <th class="max-w-32 break-words">Code géographique officiel</th>
 
           <th></th>
@@ -88,6 +89,7 @@ export function Row({
     email_domains,
     id,
     siret,
+    verification_type,
   } = organization;
 
   const href = urls.organizations[":id"].$url({ param: { id: id } }).pathname;
@@ -106,6 +108,7 @@ export function Row({
       <td>{siret}</td>
       <td>{cached_libelle}</td>
       <td>{email_domains.map(({ domain }) => domain).join(", ")}</td>
+      <td>{verification_type}</td>
       <td>
         <a
           class="after:absolute after:inset-0 after:content-[''] focus:outline-none"

--- a/sources/web/src/routes/users/:id/organizations/index.test.ts
+++ b/sources/web/src/routes/users/:id/organizations/index.test.ts
@@ -48,6 +48,7 @@ test("GET /users/:id/organizations returns user's organizations", async () => {
   expect(html).toContain("Date de création");
   expect(html).toContain("Siret");
   expect(html).toContain("Libellé");
+  expect(html).toContain("domain_not_verified_yet");
 });
 
 test("GET /users/:id/organizations handles pagination", async () => {


### PR DESCRIPTION
**Problem**

The organizations table does not display the verification type, leaving users without visibility into the verification status of each organization.

**Proposal**

Add a “Type de vérification” column header and display the verification_type field in each row of the table.