### PR TITLE
✨ Add count badges with emojis to user table sections

### DIFF
--- a/.release-it-changeset/1783426926-badgesdecomptageavecemojisdanslessectionsutilisateur.md
+++ b/.release-it-changeset/1783426926-badgesdecomptageavecemojisdanslessectionsutilisateur.md
@@ -1,0 +1,3 @@
+✨ Badges de comptage avec émojis dans les sections utilisateur
+
+Ajoute des badges affichant le nombre d'éléments avec des émojis dans les sections repliables (🏢 organisations, 🛂 modérations, 🔐 connexions) de la page utilisateur.

--- a/e2e/features/users/jean_bon.feature
+++ b/e2e/features/users/jean_bon.feature
@@ -25,7 +25,7 @@ Fonctionnalité: Page utilisateur with moderations
     Et je vois "Dernière modification22/06/2023 16:34:34"
     Et je vois "Email vérifié envoyé le22/06/2023 16:34:34"
 
-    Alors je dois voir un tableau nommé "Liste des modérations de Jean" et contenant
+    Alors je dois voir un tableau nommé "🛂 2 modérations de Jean" et contenant
       | Type          |
       | 🕵️ A traiter |
 

--- a/e2e/features/users/raphael_alpha.feature
+++ b/e2e/features/users/raphael_alpha.feature
@@ -25,7 +25,7 @@ Fonctionnalité: Page utilisateur avec MFA
     Et je vois "Dernière modification22/06/2023 16:34:34"
     Et je vois "Email vérifié envoyé le22/06/2023 16:34:34"
 
-    Alors je dois voir un tableau nommé "Liste des modérations de Raphael" et contenant
+    Alors je dois voir un tableau nommé "🛂 2 modérations de Raphael" et contenant
       | Type           |
       | 🔓 Non vérifié |
     Et je réinitialise le contexte

--- a/e2e/features/users/raphael_beta.feature
+++ b/e2e/features/users/raphael_beta.feature
@@ -25,6 +25,6 @@ Fonctionnalité: Page utilisateur
     Et je vois "Dernière modification22/06/2023 16:34:34"
     Et je vois "Email vérifié envoyé le22/06/2023 16:34:34"
 
-    Alors je dois voir un tableau nommé "Liste des organisations de Raphael" et contenant
+    Alors je dois voir un tableau nommé "🏢 2 organisations de Raphael" et contenant
       | Libellé                                           | Siret          |
       | Direction interministerielle du numerique (DINUM) | 13002526500013 |

--- a/sources/web/src/routes/users/:id/index.tsx
+++ b/sources/web/src/routes/users/:id/index.tsx
@@ -3,7 +3,7 @@
 import { NotFoundError } from "#src/errors";
 import type { HtmxHeader } from "#src/htmx";
 import { Main_Layout } from "#src/layouts";
-import { ResetMFA, ResetPassword } from "#src/lib/users";
+import { CountUserMemberships, ResetMFA, ResetPassword } from "#src/lib/users";
 import { editor_guard } from "#src/middleware/auth";
 import type { AppContext } from "#src/middleware/context";
 import { EntitySchema } from "#src/schema";
@@ -18,8 +18,10 @@ import { get_authenticators_by_user_id } from "./get_authenticators_by_user_id.q
 import { get_franceconnect_by_user_id } from "./get_franceconnect_by_user_id.query";
 import { get_user_by_id } from "./get_user_by_id.query";
 import user_moderations_route from "./moderations";
+import { count_moderations_by_user_id } from "./moderations/count_moderations_by_user_id.query";
 import { UserNotFound } from "./not-found";
 import user_oidc_clients_route from "./oidc_clients";
+import { count_oidc_clients_by_user_id } from "./oidc_clients/count_oidc_clients_by_user_id.query";
 import user_organizations_page_route from "./organizations";
 import { UserPage } from "./page";
 
@@ -51,6 +53,18 @@ export default new Hono<AppContext>()
           id,
         );
 
+        const query_organizations_count = CountUserMemberships({
+          pg: identite_pg,
+        })(user.id);
+        const query_moderations_count = count_moderations_by_user_id(
+          identite_pg,
+          user.id,
+        );
+        const query_oidc_clients_count = count_oidc_clients_by_user_id(
+          identite_pg,
+          user.id,
+        );
+
         set(
           "page_title",
           `Utilisateur ${user.given_name} ${user.family_name} (${user.email})`,
@@ -61,6 +75,9 @@ export default new Hono<AppContext>()
             authenticators={authenticators}
             franceconnect={franceconnect}
             is_editor={is_editor}
+            query_moderations_count={query_moderations_count}
+            query_oidc_clients_count={query_oidc_clients_count}
+            query_organizations_count={query_organizations_count}
             user={user}
           />,
         );

--- a/sources/web/src/routes/users/:id/moderations/count_moderations_by_user_id.query.ts
+++ b/sources/web/src/routes/users/:id/moderations/count_moderations_by_user_id.query.ts
@@ -1,0 +1,21 @@
+//
+
+import {
+  schema,
+  type IdentiteProconnectPgDatabase,
+} from "@~/identite-proconnect/database";
+import { count as drizzle_count, eq } from "drizzle-orm";
+
+//
+
+export async function count_moderations_by_user_id(
+  pg: IdentiteProconnectPgDatabase,
+  user_id: number,
+) {
+  const [{ value: count } = { value: NaN }] = await pg
+    .select({ value: drizzle_count() })
+    .from(schema.moderations)
+    .where(eq(schema.moderations.user_id, user_id));
+
+  return count;
+}

--- a/sources/web/src/routes/users/:id/oidc_clients/count_oidc_clients_by_user_id.query.ts
+++ b/sources/web/src/routes/users/:id/oidc_clients/count_oidc_clients_by_user_id.query.ts
@@ -1,0 +1,21 @@
+//
+
+import {
+  schema,
+  type IdentiteProconnectPgDatabase,
+} from "@~/identite-proconnect/database";
+import { count as drizzle_count, eq } from "drizzle-orm";
+
+//
+
+export async function count_oidc_clients_by_user_id(
+  pg: IdentiteProconnectPgDatabase,
+  user_id: number,
+) {
+  const [{ value: count } = { value: NaN }] = await pg
+    .select({ value: drizzle_count() })
+    .from(schema.users_oidc_clients)
+    .where(eq(schema.users_oidc_clients.user_id, user_id));
+
+  return count;
+}

--- a/sources/web/src/routes/users/:id/page.tsx
+++ b/sources/web/src/routes/users/:id/page.tsx
@@ -7,6 +7,7 @@ import { CopyButton, GoogleSearchButton } from "#src/ui/button/components";
 import { card } from "#src/ui/card";
 import { badge_description_list } from "#src/ui/list";
 import { FrNumberConverter } from "#src/ui/number";
+import { formattedPlural } from "#src/ui/plurial";
 import { table } from "#src/ui/table";
 import { LocalTime } from "#src/ui/time";
 import { urls } from "#src/urls";
@@ -24,11 +25,17 @@ export async function UserPage({
   authenticators,
   franceconnect,
   is_editor,
+  query_moderations_count,
+  query_oidc_clients_count,
+  query_organizations_count,
   user,
 }: {
   authenticators: Authenticators;
   franceconnect: FranceConnect;
   is_editor: boolean;
+  query_moderations_count: Promise<number>;
+  query_oidc_clients_count: Promise<number>;
+  query_organizations_count: Promise<number>;
   user: User;
 }) {
   const $organizations_describedby = hyper_ref("user_organizations");
@@ -77,6 +84,7 @@ export async function UserPage({
         <UserOrganizationsList
           describedby={$organizations_describedby}
           hx_props={hx_get_user_organizations_props}
+          query_count={query_organizations_count}
           user={user}
         />
 
@@ -85,6 +93,7 @@ export async function UserPage({
         <UserModerationsList
           describedby={$moderations_describedby}
           hx_props={hx_get_user_moderations_props}
+          query_count={query_moderations_count}
           user={user}
         />
 
@@ -93,6 +102,7 @@ export async function UserPage({
         <UserOidcClientsList
           describedby={$oidc_clients_describedby}
           hx_props={hx_get_user_oidc_clients_props}
+          query_count={query_oidc_clients_count}
           user={user}
         />
       </div>
@@ -119,21 +129,30 @@ export async function UserPage({
   );
 }
 
-function UserOrganizationsList({
+async function UserOrganizationsList({
   describedby,
   hx_props,
+  query_count,
   user,
 }: {
   describedby: string;
   hx_props: Record<string, string>;
+  query_count: Promise<number>;
   user: Pick<User, "given_name">;
 }) {
+  const count = await query_count;
+
   return (
     <section>
       <details>
         <summary>
           <h1 class="inline-block" id={describedby}>
-            Liste des organisations de {user.given_name}
+            🏢 {count}{" "}
+            {formattedPlural(count, {
+              one: "organisation",
+              other: "organisations",
+            })}{" "}
+            de {user.given_name}
           </h1>
         </summary>
         <div class="max-w-full">
@@ -149,21 +168,30 @@ function UserOrganizationsList({
   );
 }
 
-function UserModerationsList({
+async function UserModerationsList({
   describedby,
   hx_props,
+  query_count,
   user,
 }: {
   describedby: string;
   hx_props: Record<string, string>;
+  query_count: Promise<number>;
   user: Pick<User, "given_name">;
 }) {
+  const count = await query_count;
+
   return (
     <section>
       <details>
         <summary>
           <h1 class="inline-block" id={describedby}>
-            Liste des modérations de {user.given_name}
+            🛂 {count}{" "}
+            {formattedPlural(count, {
+              one: "modération",
+              other: "modérations",
+            })}{" "}
+            de {user.given_name}
           </h1>
         </summary>
         <div class="max-w-full">
@@ -179,21 +207,30 @@ function UserModerationsList({
   );
 }
 
-function UserOidcClientsList({
+async function UserOidcClientsList({
   describedby,
   hx_props,
+  query_count,
   user,
 }: {
   describedby: string;
   hx_props: Record<string, string>;
+  query_count: Promise<number>;
   user: Pick<User, "given_name">;
 }) {
+  const count = await query_count;
+
   return (
     <section>
       <details>
         <summary>
           <h1 class="inline-block" id={describedby}>
-            Historique de connexion de {user.given_name}
+            🔐 {count}{" "}
+            {formattedPlural(count, {
+              one: "connexion",
+              other: "connexions",
+            })}{" "}
+            de {user.given_name}
           </h1>
         </summary>
         <div class="max-w-full">


### PR DESCRIPTION
**Problem**

The collapsible table sections lacked count badges and emoji indicators, making it harder to scan the page.

**Proposal**

- Add dedicated count query files for moderations and OIDC clients
- Reuse existing CountUserMemberships for organizations
- Display counts with formattedPlural and emoji per section (🏢 organizations, 🛂 moderations, 🔐 connections)
- Update e2e feature files to match new table titles