### PR TITLE
💄 Add Interne column to user organizations table

### DIFF
--- a/.release-it-changeset/1783430113-colonne-externedansletableaudesorganisations.md
+++ b/.release-it-changeset/1783430113-colonne-externedansletableaudesorganisations.md
@@ -1,0 +1,3 @@
+💄 Colonne Externe dans le tableau des organisations
+
+Ajoute une colonne « Externe » avec indicateur ✅/❌ dans le tableau des organisations de la page utilisateur.

--- a/e2e/features/users/raphael_beta.feature
+++ b/e2e/features/users/raphael_beta.feature
@@ -26,5 +26,5 @@ Fonctionnalité: Page utilisateur
     Et je vois "Email vérifié envoyé le22/06/2023 16:34:34"
 
     Alors je dois voir un tableau nommé "🏢 2 organisations de Raphael" et contenant
-      | Libellé                                           | Siret          |
-      | Direction interministerielle du numerique (DINUM) | 13002526500013 |
+      | Libellé                                           | Siret          | Interne |
+      | Direction interministerielle du numerique (DINUM) | 13002526500013 | ✅       |

--- a/sources/web/src/routes/users/:id/organizations/Table.tsx
+++ b/sources/web/src/routes/users/:id/organizations/Table.tsx
@@ -54,6 +54,7 @@ export async function Table({
           <th class="warp-break-word">Libellé</th>
           <th class="warp-break-word">Domains</th>
           <th class="warp-break-word">Type de vérification</th>
+          <th class="warp-break-word">Interne</th>
           <th class="max-w-32 break-words">Code géographique officiel</th>
 
           <th></th>
@@ -100,6 +101,7 @@ export function Row({
     created_at,
     email_domains,
     id,
+    is_external,
     siret,
     verification_type,
   } = organization;
@@ -121,6 +123,7 @@ export function Row({
       <td>{cached_libelle}</td>
       <td>{email_domains.map(({ domain }) => domain).join(", ")}</td>
       <td>{verification_type}</td>
+      <td>{is_external ? "❌" : "✅"}</td>
       <td>
         <a
           class="after:absolute after:inset-0 after:content-[''] focus:outline-none"

--- a/sources/web/src/routes/users/:id/organizations/index.test.ts
+++ b/sources/web/src/routes/users/:id/organizations/index.test.ts
@@ -62,6 +62,8 @@ test("GET /users/:id/organizations returns user's organizations", async () => {
   expect(html).toContain("Siret");
   expect(html).toContain("Libellé");
   expect(html).toContain("domain_not_verified_yet");
+  expect(html).toContain("Interne");
+  expect(html).toContain("✅");
   expect(html).toContain("hx-delete");
 });
 


### PR DESCRIPTION
**Problem**

The user organizations table didn't display whether a membership is internal, requiring users to check the action menu.

**Proposal**

Add an "Interne" column with ✅/❌ indicator directly in the table, matching the pattern from the organization members table.