### PR TITLE
✨ Add who is button

### DIFF
--- a/.release-it-changeset/1786012497-feature.md
+++ b/.release-it-changeset/1786012497-feature.md
@@ -1,0 +1,1 @@
+✨ Ajoute un bouton WHOIS avec le nom de domaine correspondant à la modération

--- a/sources/web/src/ui/users/Investigation/Investigation.tsx
+++ b/sources/web/src/ui/users/Investigation/Investigation.tsx
@@ -45,6 +45,16 @@ export function Investigation(props: InvestigationProps) {
           Chercher le matching
         </GoogleSearchButton>
       </li>
+      <li>
+        <a
+          class={`${button({ size: "sm", type: "tertiary" })} dark:bg-surface-hover mr-2 bg-white`}
+          href={`https://who.is/whois/${domain}`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Chercher domaine WHOIS
+        </a>
+      </li>
     </ul>
   );
 }


### PR DESCRIPTION
<img width="921" height="96" alt="Capture d’écran 2026-08-06 à 13 27 33" src="https://github.com/user-attachments/assets/22fd596f-9151-4a89-a1ad-8f1f0634a2a6" />

**Problem:**
Support is wasting time trying to find out who owns an email domain

**Fix:**
Add a button that opens a window linking to the who.is website, with the correct domain name already entered